### PR TITLE
Fix misnamed navigation properties

### DIFF
--- a/src/Domain/Entities/Inventory/ProductItem.cs
+++ b/src/Domain/Entities/Inventory/ProductItem.cs
@@ -7,7 +7,7 @@ public class ProductItem : BaseAuditableEntity
     public ProductType ProductType { get; set; } // Ürün tipi (model bazlı vs.)
 
     public Guid InventoryProductId { get; set; }
-    public InventoryProduct InventoryProducts { get; set; } = default!;
+    public InventoryProduct InventoryProduct { get; set; } = default!;
 
     public Guid? StockTransactionId { get; set; } // hangi girişten geldi
     public StockTransaction? StockTransaction { get; set; }

--- a/src/Domain/Entities/Inventory/StockTransaction.cs
+++ b/src/Domain/Entities/Inventory/StockTransaction.cs
@@ -11,7 +11,7 @@ public class StockTransaction : BaseAuditableEntity
     public decimal LaborUnitPrice { get; set; }    // İşçilik gram fiyatı
 
     public Guid InventoryProductId { get; set; }
-    public InventoryProduct InventoryProducts { get; set; } = default!;
+    public InventoryProduct InventoryProduct { get; set; } = default!;
 
     public Guid? ProductItemId { get; set; }
     public ProductItem? ProductItem { get; set; } = default!;

--- a/src/Domain/Entities/Sales/SaleItem.cs
+++ b/src/Domain/Entities/Sales/SaleItem.cs
@@ -8,10 +8,10 @@ public class SaleItem : BaseAuditableEntity
     public Sale Sale { get; set; } = default!;
 
     public Guid? ProductItemId { get; set; }
-    public ProductItem? ProductItems { get; set; }
+    public ProductItem? ProductItem { get; set; }
 
     public Guid? InventoryProductId { get; set; }
-    public InventoryProduct? InventoryProducts { get; set; }
+    public InventoryProduct? InventoryProduct { get; set; }
 
     public decimal Quantity { get; set; }
     public decimal UnitPrice { get; set; }


### PR DESCRIPTION
## Summary
- rename navigation properties that were pluralized
- fix property names in product and stock related entities

## Testing
- `dotnet build --no-restore`
- `dotnet test tests/Application.UnitTests/Application.UnitTests.csproj --no-build --verbosity minimal`
- `dotnet test tests/Domain.UnitTests/Domain.UnitTests.csproj --no-build --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_68488deb621c832f8888e2e61f284007

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated certain property names from plural to singular in product, inventory, and sales records to improve clarity and consistency in the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->