### PR TITLE
Expose domain sets in ApplicationDbContext

### DIFF
--- a/src/Application/Common/Interfaces/IApplicationDbContext.cs
+++ b/src/Application/Common/Interfaces/IApplicationDbContext.cs
@@ -1,4 +1,9 @@
-﻿using KuyumcuStokTakip.Domain.Entities;
+using KuyumcuStokTakip.Domain.Entities;
+using KuyumcuStokTakip.Domain.Entities.Account;
+using KuyumcuStokTakip.Domain.Entities.Common;
+using KuyumcuStokTakip.Domain.Entities.Finance;
+using KuyumcuStokTakip.Domain.Entities.Inventory;
+using KuyumcuStokTakip.Domain.Entities.Sales;
 
 namespace KuyumcuStokTakip.Application.Common.Interfaces;
 
@@ -7,6 +12,36 @@ public interface IApplicationDbContext
     DbSet<TodoList> TodoLists { get; }
 
     DbSet<TodoItem> TodoItems { get; }
+
+    // Account
+    DbSet<AccountPartner> AccountPartners { get; }
+    DbSet<Customer> Customers { get; }
+    DbSet<Partner> Partners { get; }
+
+    // Common
+    DbSet<Branch> Branches { get; }
+
+    // Finance
+    DbSet<AccountTransaction> AccountTransactions { get; }
+    DbSet<CashTransaction> CashTransactions { get; }
+    DbSet<Currency> Currencies { get; }
+    DbSet<ExchangeRate> ExchangeRates { get; }
+    DbSet<Expense> Expenses { get; }
+    DbSet<PartnerAccountTransaction> PartnerAccountTransactions { get; }
+
+    // Inventory
+    DbSet<Inventory> Inventories { get; }
+    DbSet<InventoryProduct> InventoryProducts { get; }
+    DbSet<ProductCategory> ProductCategories { get; }
+    DbSet<ProductItem> ProductItems { get; }
+    DbSet<Pricing> Pricings { get; }
+    DbSet<Purity> Purities { get; }
+    DbSet<StockTransaction> StockTransactions { get; }
+    DbSet<StockUnit> StockUnits { get; }
+
+    // Sales
+    DbSet<Sale> Sales { get; }
+    DbSet<SaleItem> SaleItems { get; }
 
     Task<int> SaveChangesAsync(CancellationToken cancellationToken);
 }

--- a/src/Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/Infrastructure/Data/ApplicationDbContext.cs
@@ -1,6 +1,11 @@
 ﻿using System.Reflection;
 using KuyumcuStokTakip.Application.Common.Interfaces;
 using KuyumcuStokTakip.Domain.Entities;
+using KuyumcuStokTakip.Domain.Entities.Account;
+using KuyumcuStokTakip.Domain.Entities.Common;
+using KuyumcuStokTakip.Domain.Entities.Finance;
+using KuyumcuStokTakip.Domain.Entities.Inventory;
+using KuyumcuStokTakip.Domain.Entities.Sales;
 using KuyumcuStokTakip.Infrastructure.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
@@ -15,9 +20,39 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>, IApplica
 
     public DbSet<TodoItem> TodoItems => Set<TodoItem>();
 
+    // Account
+    public DbSet<AccountPartner> AccountPartners => Set<AccountPartner>();
+    public DbSet<Customer> Customers => Set<Customer>();
+    public DbSet<Partner> Partners => Set<Partner>();
+
+    // Common
+    public DbSet<Branch> Branches => Set<Branch>();
+
+    // Finance
+    public DbSet<AccountTransaction> AccountTransactions => Set<AccountTransaction>();
+    public DbSet<CashTransaction> CashTransactions => Set<CashTransaction>();
+    public DbSet<Currency> Currencies => Set<Currency>();
+    public DbSet<ExchangeRate> ExchangeRates => Set<ExchangeRate>();
+    public DbSet<Expense> Expenses => Set<Expense>();
+    public DbSet<PartnerAccountTransaction> PartnerAccountTransactions => Set<PartnerAccountTransaction>();
+
+    // Inventory
+    public DbSet<Inventory> Inventories => Set<Inventory>();
+    public DbSet<InventoryProduct> InventoryProducts => Set<InventoryProduct>();
+    public DbSet<ProductCategory> ProductCategories => Set<ProductCategory>();
+    public DbSet<ProductItem> ProductItems => Set<ProductItem>();
+    public DbSet<Pricing> Pricings => Set<Pricing>();
+    public DbSet<Purity> Purities => Set<Purity>();
+    public DbSet<StockTransaction> StockTransactions => Set<StockTransaction>();
+    public DbSet<StockUnit> StockUnits => Set<StockUnit>();
+
+    // Sales
+    public DbSet<Sale> Sales => Set<Sale>();
+    public DbSet<SaleItem> SaleItems => Set<SaleItem>();
+
     protected override void OnModelCreating(ModelBuilder builder)
     {
         base.OnModelCreating(builder);
-        builder.ApplyConfigurationsFromAssembly(Assembly.GetExecutingAssembly());
+        builder.ApplyConfigurationsFromAssembly(typeof(ApplicationDbContext).Assembly);
     }
 }


### PR DESCRIPTION
## Summary
- add `DbSet` properties for domain entities in `ApplicationDbContext`
- expose the same sets in `IApplicationDbContext`
- apply configurations using `typeof(ApplicationDbContext).Assembly`

## Testing
- `dotnet build --no-restore` *(fails: command not found)*
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684894152270832fa9ee11733739a93e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced expanded support for managing accounts, finance, inventory, and sales entities within the application.
  - Added new capabilities for handling partners, customers, branches, transactions, currencies, inventory items, products, pricing, stock, and sales records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->