### PR TITLE
Add EF Core configurations for new entities

### DIFF
--- a/src/Infrastructure/Data/Configurations/AccountPartnerConfiguration.cs
+++ b/src/Infrastructure/Data/Configurations/AccountPartnerConfiguration.cs
@@ -1,0 +1,39 @@
+using KuyumcuStokTakip.Domain.Entities.Account;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace KuyumcuStokTakip.Infrastructure.Data.Configurations;
+
+public class AccountPartnerConfiguration : IEntityTypeConfiguration<AccountPartner>
+{
+    public void Configure(EntityTypeBuilder<AccountPartner> builder)
+    {
+        builder.ToTable("AccountPartners");
+
+        builder.HasKey(a => a.Id);
+
+        builder.Property(a => a.FirstName)
+            .HasMaxLength(100)
+            .IsRequired();
+
+        builder.Property(a => a.LastName)
+            .HasMaxLength(100)
+            .IsRequired();
+
+        builder.Property(a => a.Phone)
+            .HasMaxLength(50);
+
+        builder.Property(a => a.Email)
+            .HasMaxLength(100);
+
+        builder.Property(a => a.Address)
+            .HasMaxLength(500);
+
+        builder.Property(a => a.Notes)
+            .HasMaxLength(500);
+
+        builder.HasOne(a => a.Partner)
+            .WithMany(p => p.ContactPersons)
+            .HasForeignKey(a => a.PartnerId);
+    }
+}

--- a/src/Infrastructure/Data/Configurations/AccountTransactionConfiguration.cs
+++ b/src/Infrastructure/Data/Configurations/AccountTransactionConfiguration.cs
@@ -1,0 +1,18 @@
+using KuyumcuStokTakip.Domain.Entities.Finance;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace KuyumcuStokTakip.Infrastructure.Data.Configurations;
+
+public class AccountTransactionConfiguration : IEntityTypeConfiguration<AccountTransaction>
+{
+    public void Configure(EntityTypeBuilder<AccountTransaction> builder)
+    {
+        builder.ToTable("AccountTransactions");
+
+        builder.HasKey(t => t.Id);
+
+        builder.Property(t => t.Amount).HasColumnType("decimal(18,2)");
+        builder.Property(t => t.Description).HasMaxLength(500);
+    }
+}

--- a/src/Infrastructure/Data/Configurations/BranchConfiguration.cs
+++ b/src/Infrastructure/Data/Configurations/BranchConfiguration.cs
@@ -1,0 +1,31 @@
+using KuyumcuStokTakip.Domain.Entities.Common;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace KuyumcuStokTakip.Infrastructure.Data.Configurations;
+
+public class BranchConfiguration : IEntityTypeConfiguration<Branch>
+{
+    public void Configure(EntityTypeBuilder<Branch> builder)
+    {
+        builder.ToTable("Branches");
+
+        builder.HasKey(b => b.Id);
+
+        builder.Property(b => b.Name)
+            .HasMaxLength(200)
+            .IsRequired();
+
+        builder.Property(b => b.Location)
+            .HasMaxLength(200);
+
+        builder.Property(b => b.Phone)
+            .HasMaxLength(50);
+
+        builder.Property(b => b.Email)
+            .HasMaxLength(100);
+
+        builder.Ignore(b => b.InventoryProducts);
+        builder.Ignore(b => b.CashTransactions);
+    }
+}

--- a/src/Infrastructure/Data/Configurations/CashTransactionConfiguration.cs
+++ b/src/Infrastructure/Data/Configurations/CashTransactionConfiguration.cs
@@ -1,0 +1,27 @@
+using KuyumcuStokTakip.Domain.Entities.Finance;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace KuyumcuStokTakip.Infrastructure.Data.Configurations;
+
+public class CashTransactionConfiguration : IEntityTypeConfiguration<CashTransaction>
+{
+    public void Configure(EntityTypeBuilder<CashTransaction> builder)
+    {
+        builder.ToTable("CashTransactions");
+
+        builder.HasKey(t => t.Id);
+
+        builder.Property(t => t.Amount).HasColumnType("decimal(18,2)");
+        builder.Property(t => t.Currency).HasMaxLength(10);
+        builder.Property(t => t.Description).HasMaxLength(500);
+
+        builder.HasOne(t => t.Customer)
+            .WithMany()
+            .HasForeignKey(t => t.CustomerId);
+
+        builder.HasOne(t => t.Partner)
+            .WithMany()
+            .HasForeignKey(t => t.PartnerId);
+    }
+}

--- a/src/Infrastructure/Data/Configurations/CurrencyConfiguration.cs
+++ b/src/Infrastructure/Data/Configurations/CurrencyConfiguration.cs
@@ -1,0 +1,26 @@
+using KuyumcuStokTakip.Domain.Entities.Finance;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace KuyumcuStokTakip.Infrastructure.Data.Configurations;
+
+public class CurrencyConfiguration : IEntityTypeConfiguration<Currency>
+{
+    public void Configure(EntityTypeBuilder<Currency> builder)
+    {
+        builder.ToTable("Currencies");
+
+        builder.HasKey(c => c.Id);
+
+        builder.Property(c => c.Code)
+            .HasMaxLength(10)
+            .IsRequired();
+
+        builder.Property(c => c.Name)
+            .HasMaxLength(100)
+            .IsRequired();
+
+        builder.Property(c => c.Symbol)
+            .HasMaxLength(10);
+    }
+}

--- a/src/Infrastructure/Data/Configurations/CustomerConfiguration.cs
+++ b/src/Infrastructure/Data/Configurations/CustomerConfiguration.cs
@@ -1,0 +1,38 @@
+using KuyumcuStokTakip.Domain.Entities.Account;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace KuyumcuStokTakip.Infrastructure.Data.Configurations;
+
+public class CustomerConfiguration : IEntityTypeConfiguration<Customer>
+{
+    public void Configure(EntityTypeBuilder<Customer> builder)
+    {
+        builder.ToTable("Customers");
+
+        builder.HasKey(c => c.Id);
+
+        builder.Property(c => c.FirstName)
+            .HasMaxLength(100)
+            .IsRequired();
+
+        builder.Property(c => c.LastName)
+            .HasMaxLength(100)
+            .IsRequired();
+
+        builder.Property(c => c.Phone)
+            .HasMaxLength(50);
+
+        builder.Property(c => c.Email)
+            .HasMaxLength(100);
+
+        builder.Property(c => c.Address)
+            .HasMaxLength(500);
+
+        builder.Property(c => c.Notes)
+            .HasMaxLength(500);
+
+        builder.Ignore(c => c.StockTransactions);
+        builder.Ignore(c => c.AccountTransactions);
+    }
+}

--- a/src/Infrastructure/Data/Configurations/ExchangeRateConfiguration.cs
+++ b/src/Infrastructure/Data/Configurations/ExchangeRateConfiguration.cs
@@ -1,0 +1,22 @@
+using KuyumcuStokTakip.Domain.Entities.Finance;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace KuyumcuStokTakip.Infrastructure.Data.Configurations;
+
+public class ExchangeRateConfiguration : IEntityTypeConfiguration<ExchangeRate>
+{
+    public void Configure(EntityTypeBuilder<ExchangeRate> builder)
+    {
+        builder.ToTable("ExchangeRates");
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.BuyRate).HasColumnType("decimal(18,4)");
+        builder.Property(e => e.SellRate).HasColumnType("decimal(18,4)");
+
+        builder.HasOne(e => e.Currency)
+            .WithMany()
+            .HasForeignKey(e => e.CurrencyId);
+    }
+}

--- a/src/Infrastructure/Data/Configurations/ExpenseConfiguration.cs
+++ b/src/Infrastructure/Data/Configurations/ExpenseConfiguration.cs
@@ -1,0 +1,30 @@
+using KuyumcuStokTakip.Domain.Entities.Finance;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace KuyumcuStokTakip.Infrastructure.Data.Configurations;
+
+public class ExpenseConfiguration : IEntityTypeConfiguration<Expense>
+{
+    public void Configure(EntityTypeBuilder<Expense> builder)
+    {
+        builder.ToTable("Expenses");
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.ExpenseType)
+            .HasMaxLength(100)
+            .IsRequired();
+
+        builder.Property(e => e.Description)
+            .HasMaxLength(500);
+
+        builder.Property(e => e.PaymentMethod)
+            .HasMaxLength(50);
+
+        builder.Property(e => e.Currency)
+            .HasMaxLength(10);
+
+        builder.Property(e => e.Amount).HasColumnType("decimal(18,2)");
+    }
+}

--- a/src/Infrastructure/Data/Configurations/InventoryConfiguration.cs
+++ b/src/Infrastructure/Data/Configurations/InventoryConfiguration.cs
@@ -1,0 +1,33 @@
+using KuyumcuStokTakip.Domain.Entities.Inventory;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace KuyumcuStokTakip.Infrastructure.Data.Configurations;
+
+public class InventoryConfiguration : IEntityTypeConfiguration<Inventory>
+{
+    public void Configure(EntityTypeBuilder<Inventory> builder)
+    {
+        builder.ToTable("Inventories");
+
+        builder.HasKey(i => i.Id);
+
+        builder.Property(i => i.Code)
+            .HasMaxLength(100)
+            .IsRequired();
+
+        builder.Property(i => i.Name)
+            .HasMaxLength(200)
+            .IsRequired();
+
+        builder.Property(i => i.Description)
+            .HasMaxLength(500);
+
+        builder.HasOne(i => i.AccountPartner)
+            .WithMany()
+            .HasForeignKey(i => i.AccountPartnerId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.Ignore(i => i.Transactions);
+    }
+}

--- a/src/Infrastructure/Data/Configurations/InventoryProductConfiguration.cs
+++ b/src/Infrastructure/Data/Configurations/InventoryProductConfiguration.cs
@@ -1,0 +1,51 @@
+using KuyumcuStokTakip.Domain.Entities.Inventory;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace KuyumcuStokTakip.Infrastructure.Data.Configurations;
+
+public class InventoryProductConfiguration : IEntityTypeConfiguration<InventoryProduct>
+{
+    public void Configure(EntityTypeBuilder<InventoryProduct> builder)
+    {
+        builder.ToTable("InventoryProducts");
+
+        builder.HasKey(p => p.Id);
+
+        builder.Property(p => p.Code)
+            .HasMaxLength(100)
+            .IsRequired();
+
+        builder.Property(p => p.Name)
+            .HasMaxLength(200)
+            .IsRequired();
+
+        builder.Property(p => p.Description)
+            .HasMaxLength(500);
+
+        builder.Property(p => p.TotalWeight).HasColumnType("decimal(18,2)");
+        builder.Property(p => p.TotalPieceCount).HasColumnType("decimal(18,2)");
+        builder.Property(p => p.TotalLaborCost).HasColumnType("decimal(18,2)");
+        builder.Property(p => p.TotalMaterialCost).HasColumnType("decimal(18,2)");
+        builder.Ignore(p => p.TotalCost);
+
+        builder.HasOne(p => p.Category)
+            .WithMany(c => c.InventoryProducts)
+            .HasForeignKey(p => p.CategoryId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne(p => p.Inventory)
+            .WithMany()
+            .HasForeignKey(p => p.InventoryId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne(p => p.Unit)
+            .WithMany(u => u.InventoryProducts)
+            .HasForeignKey(p => p.UnitId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasMany(p => p.Transactions)
+            .WithOne(t => t.InventoryProduct)
+            .HasForeignKey(t => t.InventoryProductId);
+    }
+}

--- a/src/Infrastructure/Data/Configurations/PartnerAccountTransactionConfiguration.cs
+++ b/src/Infrastructure/Data/Configurations/PartnerAccountTransactionConfiguration.cs
@@ -1,0 +1,22 @@
+using KuyumcuStokTakip.Domain.Entities.Finance;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace KuyumcuStokTakip.Infrastructure.Data.Configurations;
+
+public class PartnerAccountTransactionConfiguration : IEntityTypeConfiguration<PartnerAccountTransaction>
+{
+    public void Configure(EntityTypeBuilder<PartnerAccountTransaction> builder)
+    {
+        builder.ToTable("PartnerAccountTransactions");
+
+        builder.HasKey(p => p.Id);
+
+        builder.Property(p => p.Amount).HasColumnType("decimal(18,2)");
+        builder.Property(p => p.Description).HasMaxLength(500);
+
+        builder.HasOne(p => p.Partner)
+            .WithMany()
+            .HasForeignKey(p => p.PartnerId);
+    }
+}

--- a/src/Infrastructure/Data/Configurations/PartnerConfiguration.cs
+++ b/src/Infrastructure/Data/Configurations/PartnerConfiguration.cs
@@ -1,0 +1,39 @@
+using KuyumcuStokTakip.Domain.Entities.Account;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace KuyumcuStokTakip.Infrastructure.Data.Configurations;
+
+public class PartnerConfiguration : IEntityTypeConfiguration<Partner>
+{
+    public void Configure(EntityTypeBuilder<Partner> builder)
+    {
+        builder.ToTable("Partners");
+
+        builder.HasKey(p => p.Id);
+
+        builder.Property(p => p.Name)
+            .HasMaxLength(200)
+            .IsRequired();
+
+        builder.Property(p => p.Type)
+            .HasMaxLength(100)
+            .IsRequired();
+
+        builder.Property(p => p.ParnerPhone)
+            .HasMaxLength(50);
+
+        builder.Property(p => p.ParnerEmail)
+            .HasMaxLength(100);
+
+        builder.Property(p => p.ParnerAddress)
+            .HasMaxLength(500);
+
+        builder.Property(p => p.Note)
+            .HasMaxLength(500);
+
+        builder.Ignore(p => p.IncomingTransactions);
+        builder.Ignore(p => p.OutgoingTransactions);
+        builder.Ignore(p => p.AccountTransactions);
+    }
+}

--- a/src/Infrastructure/Data/Configurations/PricingConfiguration.cs
+++ b/src/Infrastructure/Data/Configurations/PricingConfiguration.cs
@@ -1,0 +1,23 @@
+using KuyumcuStokTakip.Domain.Entities.Inventory;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace KuyumcuStokTakip.Infrastructure.Data.Configurations;
+
+public class PricingConfiguration : IEntityTypeConfiguration<Pricing>
+{
+    public void Configure(EntityTypeBuilder<Pricing> builder)
+    {
+        builder.ToTable("Pricings");
+
+        builder.HasKey(p => p.Id);
+
+        builder.Property(p => p.PurchasePrice).HasColumnType("decimal(18,2)");
+        builder.Property(p => p.SalePrice).HasColumnType("decimal(18,2)");
+
+        builder.HasOne<ProductItem>()
+            .WithMany()
+            .HasForeignKey(p => p.ProductItemId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/Infrastructure/Data/Configurations/ProductCategoryConfiguration.cs
+++ b/src/Infrastructure/Data/Configurations/ProductCategoryConfiguration.cs
@@ -1,0 +1,26 @@
+using KuyumcuStokTakip.Domain.Entities.Inventory;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace KuyumcuStokTakip.Infrastructure.Data.Configurations;
+
+public class ProductCategoryConfiguration : IEntityTypeConfiguration<ProductCategory>
+{
+    public void Configure(EntityTypeBuilder<ProductCategory> builder)
+    {
+        builder.ToTable("ProductCategories");
+
+        builder.HasKey(c => c.Id);
+
+        builder.Property(c => c.Name)
+            .HasMaxLength(200)
+            .IsRequired();
+
+        builder.Property(c => c.Description)
+            .HasMaxLength(500);
+
+        builder.HasMany(c => c.InventoryProducts)
+            .WithOne(p => p.Category)
+            .HasForeignKey(p => p.CategoryId);
+    }
+}

--- a/src/Infrastructure/Data/Configurations/ProductItemConfiguration.cs
+++ b/src/Infrastructure/Data/Configurations/ProductItemConfiguration.cs
@@ -1,0 +1,42 @@
+using KuyumcuStokTakip.Domain.Entities.Inventory;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace KuyumcuStokTakip.Infrastructure.Data.Configurations;
+
+public class ProductItemConfiguration : IEntityTypeConfiguration<ProductItem>
+{
+    public void Configure(EntityTypeBuilder<ProductItem> builder)
+    {
+        builder.ToTable("ProductItems");
+
+        builder.HasKey(i => i.Id);
+
+        builder.Property(i => i.Barcode)
+            .HasMaxLength(200)
+            .IsRequired();
+
+        builder.Property(i => i.Size)
+            .HasMaxLength(100);
+
+        builder.Property(i => i.Description)
+            .HasMaxLength(500);
+
+        builder.Property(i => i.Weight).HasColumnType("decimal(18,2)");
+        builder.Property(i => i.LaborCost).HasColumnType("decimal(18,2)");
+        builder.Property(i => i.Cost).HasColumnType("decimal(18,2)");
+
+        builder.HasOne(i => i.InventoryProduct)
+            .WithMany()
+            .HasForeignKey(i => i.InventoryProductId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne(i => i.StockTransaction)
+            .WithMany()
+            .HasForeignKey(i => i.StockTransactionId);
+
+        builder.HasOne(i => i.Purity)
+            .WithMany()
+            .HasForeignKey(i => i.PurityId);
+    }
+}

--- a/src/Infrastructure/Data/Configurations/PurityConfiguration.cs
+++ b/src/Infrastructure/Data/Configurations/PurityConfiguration.cs
@@ -1,0 +1,19 @@
+using KuyumcuStokTakip.Domain.Entities.Inventory;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace KuyumcuStokTakip.Infrastructure.Data.Configurations;
+
+public class PurityConfiguration : IEntityTypeConfiguration<Purity>
+{
+    public void Configure(EntityTypeBuilder<Purity> builder)
+    {
+        builder.ToTable("Purities");
+
+        builder.HasKey(p => p.Id);
+
+        builder.Property(p => p.Name)
+            .HasMaxLength(50)
+            .IsRequired();
+    }
+}

--- a/src/Infrastructure/Data/Configurations/SaleConfiguration.cs
+++ b/src/Infrastructure/Data/Configurations/SaleConfiguration.cs
@@ -1,0 +1,29 @@
+using KuyumcuStokTakip.Domain.Entities.Sales;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace KuyumcuStokTakip.Infrastructure.Data.Configurations;
+
+public class SaleConfiguration : IEntityTypeConfiguration<Sale>
+{
+    public void Configure(EntityTypeBuilder<Sale> builder)
+    {
+        builder.ToTable("Sales");
+
+        builder.HasKey(s => s.Id);
+
+        builder.Property(s => s.Currency)
+            .HasMaxLength(10);
+
+        builder.Property(s => s.Description)
+            .HasMaxLength(500);
+
+        builder.HasOne(s => s.Customer)
+            .WithMany()
+            .HasForeignKey(s => s.CustomerId);
+
+        builder.HasMany(s => s.Items)
+            .WithOne(i => i.Sale)
+            .HasForeignKey(i => i.SaleId);
+    }
+}

--- a/src/Infrastructure/Data/Configurations/SaleItemConfiguration.cs
+++ b/src/Infrastructure/Data/Configurations/SaleItemConfiguration.cs
@@ -1,0 +1,33 @@
+using KuyumcuStokTakip.Domain.Entities.Sales;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace KuyumcuStokTakip.Infrastructure.Data.Configurations;
+
+public class SaleItemConfiguration : IEntityTypeConfiguration<SaleItem>
+{
+    public void Configure(EntityTypeBuilder<SaleItem> builder)
+    {
+        builder.ToTable("SaleItems");
+
+        builder.HasKey(i => i.Id);
+
+        builder.Property(i => i.Quantity).HasColumnType("decimal(18,2)");
+        builder.Property(i => i.UnitPrice).HasColumnType("decimal(18,2)");
+
+        builder.Ignore(i => i.Total);
+
+        builder.HasOne(i => i.Sale)
+            .WithMany(s => s.Items)
+            .HasForeignKey(i => i.SaleId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(i => i.ProductItem)
+            .WithMany()
+            .HasForeignKey(i => i.ProductItemId);
+
+        builder.HasOne(i => i.InventoryProduct)
+            .WithMany()
+            .HasForeignKey(i => i.InventoryProductId);
+    }
+}

--- a/src/Infrastructure/Data/Configurations/StockTransactionConfiguration.cs
+++ b/src/Infrastructure/Data/Configurations/StockTransactionConfiguration.cs
@@ -1,0 +1,46 @@
+using KuyumcuStokTakip.Domain.Entities.Inventory;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace KuyumcuStokTakip.Infrastructure.Data.Configurations;
+
+public class StockTransactionConfiguration : IEntityTypeConfiguration<StockTransaction>
+{
+    public void Configure(EntityTypeBuilder<StockTransaction> builder)
+    {
+        builder.ToTable("StockTransactions");
+
+        builder.HasKey(t => t.Id);
+
+        builder.Property(t => t.PureGram).HasColumnType("decimal(18,2)");
+        builder.Property(t => t.PureUnitPrice).HasColumnType("decimal(18,2)");
+        builder.Property(t => t.LaborUnitPrice).HasColumnType("decimal(18,2)");
+        builder.Property(t => t.Quantity).HasColumnType("decimal(18,2)");
+        builder.Property(t => t.UnitPrice).HasColumnType("decimal(18,2)");
+        builder.Property(t => t.Weight).HasColumnType("decimal(18,2)");
+        builder.Property(t => t.TotalCost).HasColumnType("decimal(18,2)");
+
+        builder.Property(t => t.Description).HasMaxLength(500);
+
+        builder.HasOne(t => t.InventoryProduct)
+            .WithMany(p => p.Transactions)
+            .HasForeignKey(t => t.InventoryProductId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(t => t.ProductItem)
+            .WithMany()
+            .HasForeignKey(t => t.ProductItemId);
+
+        builder.HasOne(t => t.SourceCompany)
+            .WithMany()
+            .HasForeignKey(t => t.SourceCompanyId);
+
+        builder.HasOne(t => t.TargetCompany)
+            .WithMany()
+            .HasForeignKey(t => t.TargetCompanyId);
+
+        builder.HasOne(t => t.Customer)
+            .WithMany()
+            .HasForeignKey(t => t.CustomerId);
+    }
+}

--- a/src/Infrastructure/Data/Configurations/StockUnitConfiguration.cs
+++ b/src/Infrastructure/Data/Configurations/StockUnitConfiguration.cs
@@ -1,0 +1,30 @@
+using KuyumcuStokTakip.Domain.Entities.Inventory;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace KuyumcuStokTakip.Infrastructure.Data.Configurations;
+
+public class StockUnitConfiguration : IEntityTypeConfiguration<StockUnit>
+{
+    public void Configure(EntityTypeBuilder<StockUnit> builder)
+    {
+        builder.ToTable("StockUnits");
+
+        builder.HasKey(u => u.Id);
+
+        builder.Property(u => u.Name)
+            .HasMaxLength(100)
+            .IsRequired();
+
+        builder.Property(u => u.Symbol)
+            .HasMaxLength(50)
+            .IsRequired();
+
+        builder.Property(u => u.Description)
+            .HasMaxLength(500);
+
+        builder.HasMany(u => u.InventoryProducts)
+            .WithOne(p => p.Unit)
+            .HasForeignKey(p => p.UnitId);
+    }
+}


### PR DESCRIPTION
## Summary
- map inventory tables with InventoryConfiguration
- configure StockTransaction, Sale and related items
- add configuration for account, finance and inventory entities so `ApplyConfigurationsFromAssembly` loads them

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: Docker and browser dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_684896288a90832fa1f7d53a2f3a02b3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced comprehensive configuration for various entities, including accounts, transactions, branches, customers, inventory, partners, pricing, products, sales, and stock units.
  - Enhanced data integrity through property constraints (e.g., required fields, maximum lengths, decimal precision).
  - Established and refined relationships between entities, supporting complex data structures and business logic.
  - Improved database mapping and schema consistency for all core business entities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->