### PR TITLE
Add sample data seeding

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -46,5 +46,6 @@
     <PackageVersion Include="Microsoft.Playwright" Version="1.48.0" />
     <PackageVersion Include="SpecFlow.Plus.LivingDocPlugin" Version="3.9.57" />
     <PackageVersion Include="SpecFlow.NUnit" Version="3.9.74" />
+    <PackageVersion Include="Bogus" Version="35.6.3" />
   </ItemGroup>
 </Project>

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -16,6 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Bogus" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- install Bogus
- seed partners, inventories, product categories, stock units, products, stock transactions and sales

## Testing
- `dotnet test` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68489b851fd8832f82114c4f1f19cafd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added initial sample data for partners, inventories, product categories, stock units, inventory products, stock transactions, and sales during database setup.
- **Chores**
  - Introduced a new library to support sample data generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->