### PR TITLE
Add sample features for InventoryProduct and Expense

### DIFF
--- a/src/Application/Expenses/Commands/CreateExpense/CreateExpense.cs
+++ b/src/Application/Expenses/Commands/CreateExpense/CreateExpense.cs
@@ -1,0 +1,41 @@
+using KuyumcuStokTakip.Application.Common.Interfaces;
+using KuyumcuStokTakip.Domain.Entities.Finance;
+
+namespace KuyumcuStokTakip.Application.Expenses.Commands.CreateExpense;
+
+public record CreateExpenseCommand : IRequest<int>
+{
+    public DateTime Date { get; init; } = DateTime.UtcNow;
+    public string ExpenseType { get; init; } = string.Empty;
+    public decimal Amount { get; init; }
+    public string? Description { get; init; }
+    public string? PaymentMethod { get; init; }
+    public string? Currency { get; init; }
+}
+
+public class CreateExpenseCommandHandler : IRequestHandler<CreateExpenseCommand, int>
+{
+    private readonly IApplicationDbContext _context;
+
+    public CreateExpenseCommandHandler(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<int> Handle(CreateExpenseCommand request, CancellationToken cancellationToken)
+    {
+        var entity = new Expense
+        {
+            Date = request.Date,
+            ExpenseType = request.ExpenseType,
+            Amount = request.Amount,
+            Description = request.Description,
+            PaymentMethod = request.PaymentMethod,
+            Currency = request.Currency
+        };
+
+        _context.Expenses.Add(entity);
+        await _context.SaveChangesAsync(cancellationToken);
+        return entity.Id;
+    }
+}

--- a/src/Application/Expenses/Commands/CreateExpense/CreateExpenseCommandValidator.cs
+++ b/src/Application/Expenses/Commands/CreateExpense/CreateExpenseCommandValidator.cs
@@ -1,0 +1,10 @@
+namespace KuyumcuStokTakip.Application.Expenses.Commands.CreateExpense;
+
+public class CreateExpenseCommandValidator : AbstractValidator<CreateExpenseCommand>
+{
+    public CreateExpenseCommandValidator()
+    {
+        RuleFor(v => v.ExpenseType).NotEmpty();
+        RuleFor(v => v.Amount).GreaterThan(0);
+    }
+}

--- a/src/Application/Expenses/Commands/DeleteExpense/DeleteExpense.cs
+++ b/src/Application/Expenses/Commands/DeleteExpense/DeleteExpense.cs
@@ -1,0 +1,24 @@
+using KuyumcuStokTakip.Application.Common.Interfaces;
+
+namespace KuyumcuStokTakip.Application.Expenses.Commands.DeleteExpense;
+
+public record DeleteExpenseCommand(int Id) : IRequest;
+
+public class DeleteExpenseCommandHandler : IRequestHandler<DeleteExpenseCommand>
+{
+    private readonly IApplicationDbContext _context;
+
+    public DeleteExpenseCommandHandler(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task Handle(DeleteExpenseCommand request, CancellationToken cancellationToken)
+    {
+        var entity = await _context.Expenses.FindAsync(new object[] { request.Id }, cancellationToken);
+        Guard.Against.NotFound(request.Id, entity);
+
+        _context.Expenses.Remove(entity!);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Application/Expenses/Commands/UpdateExpense/UpdateExpense.cs
+++ b/src/Application/Expenses/Commands/UpdateExpense/UpdateExpense.cs
@@ -1,0 +1,39 @@
+using KuyumcuStokTakip.Application.Common.Interfaces;
+
+namespace KuyumcuStokTakip.Application.Expenses.Commands.UpdateExpense;
+
+public record UpdateExpenseCommand : IRequest
+{
+    public int Id { get; init; }
+    public DateTime Date { get; init; } = DateTime.UtcNow;
+    public string ExpenseType { get; init; } = string.Empty;
+    public decimal Amount { get; init; }
+    public string? Description { get; init; }
+    public string? PaymentMethod { get; init; }
+    public string? Currency { get; init; }
+}
+
+public class UpdateExpenseCommandHandler : IRequestHandler<UpdateExpenseCommand>
+{
+    private readonly IApplicationDbContext _context;
+
+    public UpdateExpenseCommandHandler(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task Handle(UpdateExpenseCommand request, CancellationToken cancellationToken)
+    {
+        var entity = await _context.Expenses.FindAsync(new object[] { request.Id }, cancellationToken);
+        Guard.Against.NotFound(request.Id, entity);
+
+        entity!.Date = request.Date;
+        entity.ExpenseType = request.ExpenseType;
+        entity.Amount = request.Amount;
+        entity.Description = request.Description;
+        entity.PaymentMethod = request.PaymentMethod;
+        entity.Currency = request.Currency;
+
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Application/Expenses/Commands/UpdateExpense/UpdateExpenseCommandValidator.cs
+++ b/src/Application/Expenses/Commands/UpdateExpense/UpdateExpenseCommandValidator.cs
@@ -1,0 +1,11 @@
+namespace KuyumcuStokTakip.Application.Expenses.Commands.UpdateExpense;
+
+public class UpdateExpenseCommandValidator : AbstractValidator<UpdateExpenseCommand>
+{
+    public UpdateExpenseCommandValidator()
+    {
+        RuleFor(v => v.Id).GreaterThan(0);
+        RuleFor(v => v.ExpenseType).NotEmpty();
+        RuleFor(v => v.Amount).GreaterThan(0);
+    }
+}

--- a/src/Application/Expenses/Queries/GetExpenses/ExpenseDto.cs
+++ b/src/Application/Expenses/Queries/GetExpenses/ExpenseDto.cs
@@ -1,0 +1,22 @@
+using KuyumcuStokTakip.Domain.Entities.Finance;
+
+namespace KuyumcuStokTakip.Application.Expenses.Queries.GetExpenses;
+
+public class ExpenseDto
+{
+    public int Id { get; init; }
+    public DateTime Date { get; init; }
+    public string ExpenseType { get; init; } = string.Empty;
+    public decimal Amount { get; init; }
+    public string? Description { get; init; }
+    public string? PaymentMethod { get; init; }
+    public string? Currency { get; init; }
+
+    private class Mapping : Profile
+    {
+        public Mapping()
+        {
+            CreateMap<Expense, ExpenseDto>();
+        }
+    }
+}

--- a/src/Application/Expenses/Queries/GetExpenses/GetExpenses.cs
+++ b/src/Application/Expenses/Queries/GetExpenses/GetExpenses.cs
@@ -1,0 +1,31 @@
+using KuyumcuStokTakip.Application.Common.Interfaces;
+using KuyumcuStokTakip.Application.Common.Mappings;
+using KuyumcuStokTakip.Application.Common.Models;
+
+namespace KuyumcuStokTakip.Application.Expenses.Queries.GetExpenses;
+
+public record GetExpensesQuery : IRequest<PaginatedList<ExpenseDto>>
+{
+    public int PageNumber { get; init; } = 1;
+    public int PageSize { get; init; } = 10;
+}
+
+public class GetExpensesQueryHandler : IRequestHandler<GetExpensesQuery, PaginatedList<ExpenseDto>>
+{
+    private readonly IApplicationDbContext _context;
+    private readonly IMapper _mapper;
+
+    public GetExpensesQueryHandler(IApplicationDbContext context, IMapper mapper)
+    {
+        _context = context;
+        _mapper = mapper;
+    }
+
+    public async Task<PaginatedList<ExpenseDto>> Handle(GetExpensesQuery request, CancellationToken cancellationToken)
+    {
+        return await _context.Expenses
+            .OrderByDescending(x => x.Date)
+            .ProjectTo<ExpenseDto>(_mapper.ConfigurationProvider)
+            .PaginatedListAsync(request.PageNumber, request.PageSize, cancellationToken);
+    }
+}

--- a/src/Application/InventoryProducts/Commands/CreateInventoryProduct/CreateInventoryProduct.cs
+++ b/src/Application/InventoryProducts/Commands/CreateInventoryProduct/CreateInventoryProduct.cs
@@ -1,0 +1,49 @@
+using KuyumcuStokTakip.Application.Common.Interfaces;
+using KuyumcuStokTakip.Domain.Entities.Inventory;
+
+namespace KuyumcuStokTakip.Application.InventoryProducts.Commands.CreateInventoryProduct;
+
+public record CreateInventoryProductCommand : IRequest<int>
+{
+    public string Code { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public string? Description { get; init; }
+    public int CategoryId { get; init; }
+    public int InventoryId { get; init; }
+    public int UnitId { get; init; }
+    public decimal TotalWeight { get; init; }
+    public decimal TotalPieceCount { get; init; }
+    public decimal TotalLaborCost { get; init; }
+    public decimal TotalMaterialCost { get; init; }
+}
+
+public class CreateInventoryProductCommandHandler : IRequestHandler<CreateInventoryProductCommand, int>
+{
+    private readonly IApplicationDbContext _context;
+
+    public CreateInventoryProductCommandHandler(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<int> Handle(CreateInventoryProductCommand request, CancellationToken cancellationToken)
+    {
+        var entity = new InventoryProduct
+        {
+            Code = request.Code,
+            Name = request.Name,
+            Description = request.Description,
+            CategoryId = request.CategoryId,
+            InventoryId = request.InventoryId,
+            UnitId = request.UnitId,
+            TotalWeight = request.TotalWeight,
+            TotalPieceCount = request.TotalPieceCount,
+            TotalLaborCost = request.TotalLaborCost,
+            TotalMaterialCost = request.TotalMaterialCost
+        };
+
+        _context.InventoryProducts.Add(entity);
+        await _context.SaveChangesAsync(cancellationToken);
+        return entity.Id;
+    }
+}

--- a/src/Application/InventoryProducts/Commands/CreateInventoryProduct/CreateInventoryProductCommandValidator.cs
+++ b/src/Application/InventoryProducts/Commands/CreateInventoryProduct/CreateInventoryProductCommandValidator.cs
@@ -1,0 +1,13 @@
+namespace KuyumcuStokTakip.Application.InventoryProducts.Commands.CreateInventoryProduct;
+
+public class CreateInventoryProductCommandValidator : AbstractValidator<CreateInventoryProductCommand>
+{
+    public CreateInventoryProductCommandValidator()
+    {
+        RuleFor(v => v.Code).NotEmpty().MaximumLength(50);
+        RuleFor(v => v.Name).NotEmpty().MaximumLength(200);
+        RuleFor(v => v.CategoryId).GreaterThan(0);
+        RuleFor(v => v.InventoryId).GreaterThan(0);
+        RuleFor(v => v.UnitId).GreaterThan(0);
+    }
+}

--- a/src/Application/InventoryProducts/Commands/DeleteInventoryProduct/DeleteInventoryProduct.cs
+++ b/src/Application/InventoryProducts/Commands/DeleteInventoryProduct/DeleteInventoryProduct.cs
@@ -1,0 +1,24 @@
+using KuyumcuStokTakip.Application.Common.Interfaces;
+
+namespace KuyumcuStokTakip.Application.InventoryProducts.Commands.DeleteInventoryProduct;
+
+public record DeleteInventoryProductCommand(int Id) : IRequest;
+
+public class DeleteInventoryProductCommandHandler : IRequestHandler<DeleteInventoryProductCommand>
+{
+    private readonly IApplicationDbContext _context;
+
+    public DeleteInventoryProductCommandHandler(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task Handle(DeleteInventoryProductCommand request, CancellationToken cancellationToken)
+    {
+        var entity = await _context.InventoryProducts.FindAsync(new object[] { request.Id }, cancellationToken);
+        Guard.Against.NotFound(request.Id, entity);
+
+        _context.InventoryProducts.Remove(entity!);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Application/InventoryProducts/Commands/UpdateInventoryProduct/UpdateInventoryProduct.cs
+++ b/src/Application/InventoryProducts/Commands/UpdateInventoryProduct/UpdateInventoryProduct.cs
@@ -1,0 +1,47 @@
+using KuyumcuStokTakip.Application.Common.Interfaces;
+
+namespace KuyumcuStokTakip.Application.InventoryProducts.Commands.UpdateInventoryProduct;
+
+public record UpdateInventoryProductCommand : IRequest
+{
+    public int Id { get; init; }
+    public string Code { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public string? Description { get; init; }
+    public int CategoryId { get; init; }
+    public int InventoryId { get; init; }
+    public int UnitId { get; init; }
+    public decimal TotalWeight { get; init; }
+    public decimal TotalPieceCount { get; init; }
+    public decimal TotalLaborCost { get; init; }
+    public decimal TotalMaterialCost { get; init; }
+}
+
+public class UpdateInventoryProductCommandHandler : IRequestHandler<UpdateInventoryProductCommand>
+{
+    private readonly IApplicationDbContext _context;
+
+    public UpdateInventoryProductCommandHandler(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task Handle(UpdateInventoryProductCommand request, CancellationToken cancellationToken)
+    {
+        var entity = await _context.InventoryProducts.FindAsync(new object[] { request.Id }, cancellationToken);
+        Guard.Against.NotFound(request.Id, entity);
+
+        entity!.Code = request.Code;
+        entity.Name = request.Name;
+        entity.Description = request.Description;
+        entity.CategoryId = request.CategoryId;
+        entity.InventoryId = request.InventoryId;
+        entity.UnitId = request.UnitId;
+        entity.TotalWeight = request.TotalWeight;
+        entity.TotalPieceCount = request.TotalPieceCount;
+        entity.TotalLaborCost = request.TotalLaborCost;
+        entity.TotalMaterialCost = request.TotalMaterialCost;
+
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Application/InventoryProducts/Commands/UpdateInventoryProduct/UpdateInventoryProductCommandValidator.cs
+++ b/src/Application/InventoryProducts/Commands/UpdateInventoryProduct/UpdateInventoryProductCommandValidator.cs
@@ -1,0 +1,14 @@
+namespace KuyumcuStokTakip.Application.InventoryProducts.Commands.UpdateInventoryProduct;
+
+public class UpdateInventoryProductCommandValidator : AbstractValidator<UpdateInventoryProductCommand>
+{
+    public UpdateInventoryProductCommandValidator()
+    {
+        RuleFor(v => v.Id).GreaterThan(0);
+        RuleFor(v => v.Code).NotEmpty().MaximumLength(50);
+        RuleFor(v => v.Name).NotEmpty().MaximumLength(200);
+        RuleFor(v => v.CategoryId).GreaterThan(0);
+        RuleFor(v => v.InventoryId).GreaterThan(0);
+        RuleFor(v => v.UnitId).GreaterThan(0);
+    }
+}

--- a/src/Application/InventoryProducts/Queries/GetInventoryProducts/GetInventoryProducts.cs
+++ b/src/Application/InventoryProducts/Queries/GetInventoryProducts/GetInventoryProducts.cs
@@ -1,0 +1,31 @@
+using KuyumcuStokTakip.Application.Common.Interfaces;
+using KuyumcuStokTakip.Application.Common.Mappings;
+using KuyumcuStokTakip.Application.Common.Models;
+
+namespace KuyumcuStokTakip.Application.InventoryProducts.Queries.GetInventoryProducts;
+
+public record GetInventoryProductsQuery : IRequest<PaginatedList<InventoryProductDto>>
+{
+    public int PageNumber { get; init; } = 1;
+    public int PageSize { get; init; } = 10;
+}
+
+public class GetInventoryProductsQueryHandler : IRequestHandler<GetInventoryProductsQuery, PaginatedList<InventoryProductDto>>
+{
+    private readonly IApplicationDbContext _context;
+    private readonly IMapper _mapper;
+
+    public GetInventoryProductsQueryHandler(IApplicationDbContext context, IMapper mapper)
+    {
+        _context = context;
+        _mapper = mapper;
+    }
+
+    public async Task<PaginatedList<InventoryProductDto>> Handle(GetInventoryProductsQuery request, CancellationToken cancellationToken)
+    {
+        return await _context.InventoryProducts
+            .OrderBy(x => x.Name)
+            .ProjectTo<InventoryProductDto>(_mapper.ConfigurationProvider)
+            .PaginatedListAsync(request.PageNumber, request.PageSize, cancellationToken);
+    }
+}

--- a/src/Application/InventoryProducts/Queries/GetInventoryProducts/InventoryProductDto.cs
+++ b/src/Application/InventoryProducts/Queries/GetInventoryProducts/InventoryProductDto.cs
@@ -1,0 +1,26 @@
+using KuyumcuStokTakip.Domain.Entities.Inventory;
+
+namespace KuyumcuStokTakip.Application.InventoryProducts.Queries.GetInventoryProducts;
+
+public class InventoryProductDto
+{
+    public int Id { get; init; }
+    public string Code { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public string? Description { get; init; }
+    public int CategoryId { get; init; }
+    public int InventoryId { get; init; }
+    public int UnitId { get; init; }
+    public decimal TotalWeight { get; init; }
+    public decimal TotalPieceCount { get; init; }
+    public decimal TotalLaborCost { get; init; }
+    public decimal TotalMaterialCost { get; init; }
+
+    private class Mapping : Profile
+    {
+        public Mapping()
+        {
+            CreateMap<InventoryProduct, InventoryProductDto>();
+        }
+    }
+}

--- a/src/Web/Endpoints/Expenses.cs
+++ b/src/Web/Endpoints/Expenses.cs
@@ -1,0 +1,46 @@
+using KuyumcuStokTakip.Application.Common.Models;
+using KuyumcuStokTakip.Application.Expenses.Commands.CreateExpense;
+using KuyumcuStokTakip.Application.Expenses.Commands.DeleteExpense;
+using KuyumcuStokTakip.Application.Expenses.Commands.UpdateExpense;
+using KuyumcuStokTakip.Application.Expenses.Queries.GetExpenses;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace KuyumcuStokTakip.Web.Endpoints;
+
+public class Expenses : EndpointGroupBase
+{
+    public override void Map(WebApplication app)
+    {
+        app.MapGroup(this)
+            .RequireAuthorization()
+            .MapGet(GetExpenses)
+            .MapPost(CreateExpense)
+            .MapPut(UpdateExpense, "{id}")
+            .MapDelete(DeleteExpense, "{id}");
+    }
+
+    public async Task<Ok<PaginatedList<ExpenseDto>>> GetExpenses(ISender sender, [AsParameters] GetExpensesQuery query)
+    {
+        var result = await sender.Send(query);
+        return TypedResults.Ok(result);
+    }
+
+    public async Task<Created<int>> CreateExpense(ISender sender, CreateExpenseCommand command)
+    {
+        var id = await sender.Send(command);
+        return TypedResults.Created($"/{nameof(Expenses)}/{id}", id);
+    }
+
+    public async Task<Results<NoContent, BadRequest>> UpdateExpense(ISender sender, int id, UpdateExpenseCommand command)
+    {
+        if (id != command.Id) return TypedResults.BadRequest();
+        await sender.Send(command);
+        return TypedResults.NoContent();
+    }
+
+    public async Task<NoContent> DeleteExpense(ISender sender, int id)
+    {
+        await sender.Send(new DeleteExpenseCommand(id));
+        return TypedResults.NoContent();
+    }
+}

--- a/src/Web/Endpoints/InventoryProducts.cs
+++ b/src/Web/Endpoints/InventoryProducts.cs
@@ -1,0 +1,46 @@
+using KuyumcuStokTakip.Application.Common.Models;
+using KuyumcuStokTakip.Application.InventoryProducts.Commands.CreateInventoryProduct;
+using KuyumcuStokTakip.Application.InventoryProducts.Commands.DeleteInventoryProduct;
+using KuyumcuStokTakip.Application.InventoryProducts.Commands.UpdateInventoryProduct;
+using KuyumcuStokTakip.Application.InventoryProducts.Queries.GetInventoryProducts;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace KuyumcuStokTakip.Web.Endpoints;
+
+public class InventoryProducts : EndpointGroupBase
+{
+    public override void Map(WebApplication app)
+    {
+        app.MapGroup(this)
+            .RequireAuthorization()
+            .MapGet(GetInventoryProducts)
+            .MapPost(CreateInventoryProduct)
+            .MapPut(UpdateInventoryProduct, "{id}")
+            .MapDelete(DeleteInventoryProduct, "{id}");
+    }
+
+    public async Task<Ok<PaginatedList<InventoryProductDto>>> GetInventoryProducts(ISender sender, [AsParameters] GetInventoryProductsQuery query)
+    {
+        var result = await sender.Send(query);
+        return TypedResults.Ok(result);
+    }
+
+    public async Task<Created<int>> CreateInventoryProduct(ISender sender, CreateInventoryProductCommand command)
+    {
+        var id = await sender.Send(command);
+        return TypedResults.Created($"/{nameof(InventoryProducts)}/{id}", id);
+    }
+
+    public async Task<Results<NoContent, BadRequest>> UpdateInventoryProduct(ISender sender, int id, UpdateInventoryProductCommand command)
+    {
+        if (id != command.Id) return TypedResults.BadRequest();
+        await sender.Send(command);
+        return TypedResults.NoContent();
+    }
+
+    public async Task<NoContent> DeleteInventoryProduct(ISender sender, int id)
+    {
+        await sender.Send(new DeleteInventoryProductCommand(id));
+        return TypedResults.NoContent();
+    }
+}

--- a/tests/Application.FunctionalTests/Expenses/Commands/CreateExpenseTests.cs
+++ b/tests/Application.FunctionalTests/Expenses/Commands/CreateExpenseTests.cs
@@ -1,0 +1,34 @@
+using KuyumcuStokTakip.Application.Common.Exceptions;
+using KuyumcuStokTakip.Application.Expenses.Commands.CreateExpense;
+using KuyumcuStokTakip.Domain.Entities.Finance;
+
+namespace KuyumcuStokTakip.Application.FunctionalTests.Expenses.Commands;
+
+using static Testing;
+
+public class CreateExpenseTests : BaseTestFixture
+{
+    [Test]
+    public async Task ShouldRequireFields()
+    {
+        var command = new CreateExpenseCommand { Amount = 0, ExpenseType = "" };
+        await FluentActions.Invoking(() => SendAsync(command)).Should().ThrowAsync<ValidationException>();
+    }
+
+    [Test]
+    public async Task ShouldCreateExpense()
+    {
+        var command = new CreateExpenseCommand
+        {
+            ExpenseType = "Rent",
+            Amount = 100,
+            Description = "April rent"
+        };
+
+        var id = await SendAsync(command);
+        var entity = await FindAsync<Expense>(id);
+        entity.Should().NotBeNull();
+        entity!.ExpenseType.Should().Be(command.ExpenseType);
+        entity.Amount.Should().Be(command.Amount);
+    }
+}

--- a/tests/Application.FunctionalTests/Expenses/Commands/DeleteExpenseTests.cs
+++ b/tests/Application.FunctionalTests/Expenses/Commands/DeleteExpenseTests.cs
@@ -1,0 +1,27 @@
+using KuyumcuStokTakip.Application.Common.Exceptions;
+using KuyumcuStokTakip.Application.Expenses.Commands.CreateExpense;
+using KuyumcuStokTakip.Application.Expenses.Commands.DeleteExpense;
+using KuyumcuStokTakip.Domain.Entities.Finance;
+
+namespace KuyumcuStokTakip.Application.FunctionalTests.Expenses.Commands;
+
+using static Testing;
+
+public class DeleteExpenseTests : BaseTestFixture
+{
+    [Test]
+    public async Task ShouldRequireValidId()
+    {
+        var command = new DeleteExpenseCommand(99);
+        await FluentActions.Invoking(() => SendAsync(command)).Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Test]
+    public async Task ShouldDeleteExpense()
+    {
+        var id = await SendAsync(new CreateExpenseCommand { ExpenseType = "Rent", Amount = 100 });
+        await SendAsync(new DeleteExpenseCommand(id));
+        var entity = await FindAsync<Expense>(id);
+        entity.Should().BeNull();
+    }
+}

--- a/tests/Application.FunctionalTests/InventoryProducts/Commands/CreateInventoryProductTests.cs
+++ b/tests/Application.FunctionalTests/InventoryProducts/Commands/CreateInventoryProductTests.cs
@@ -1,0 +1,36 @@
+using KuyumcuStokTakip.Application.Common.Exceptions;
+using KuyumcuStokTakip.Application.InventoryProducts.Commands.CreateInventoryProduct;
+using KuyumcuStokTakip.Domain.Entities.Inventory;
+
+namespace KuyumcuStokTakip.Application.FunctionalTests.InventoryProducts.Commands;
+
+using static Testing;
+
+public class CreateInventoryProductTests : BaseTestFixture
+{
+    [Test]
+    public async Task ShouldRequireFields()
+    {
+        var command = new CreateInventoryProductCommand { Code = "", Name = "" };
+        await FluentActions.Invoking(() => SendAsync(command)).Should().ThrowAsync<ValidationException>();
+    }
+
+    [Test]
+    public async Task ShouldCreateInventoryProduct()
+    {
+        var command = new CreateInventoryProductCommand
+        {
+            Code = "P1",
+            Name = "Product 1",
+            CategoryId = 1,
+            InventoryId = 1,
+            UnitId = 1,
+            TotalWeight = 1
+        };
+
+        var id = await SendAsync(command);
+        var entity = await FindAsync<InventoryProduct>(id);
+        entity.Should().NotBeNull();
+        entity!.Code.Should().Be(command.Code);
+    }
+}

--- a/tests/Application.FunctionalTests/InventoryProducts/Commands/DeleteInventoryProductTests.cs
+++ b/tests/Application.FunctionalTests/InventoryProducts/Commands/DeleteInventoryProductTests.cs
@@ -1,0 +1,35 @@
+using KuyumcuStokTakip.Application.Common.Exceptions;
+using KuyumcuStokTakip.Application.InventoryProducts.Commands.CreateInventoryProduct;
+using KuyumcuStokTakip.Application.InventoryProducts.Commands.DeleteInventoryProduct;
+using KuyumcuStokTakip.Domain.Entities.Inventory;
+
+namespace KuyumcuStokTakip.Application.FunctionalTests.InventoryProducts.Commands;
+
+using static Testing;
+
+public class DeleteInventoryProductTests : BaseTestFixture
+{
+    [Test]
+    public async Task ShouldRequireValidId()
+    {
+        var command = new DeleteInventoryProductCommand(99);
+        await FluentActions.Invoking(() => SendAsync(command)).Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Test]
+    public async Task ShouldDeleteInventoryProduct()
+    {
+        var id = await SendAsync(new CreateInventoryProductCommand
+        {
+            Code = "P1",
+            Name = "Product 1",
+            CategoryId = 1,
+            InventoryId = 1,
+            UnitId = 1
+        });
+
+        await SendAsync(new DeleteInventoryProductCommand(id));
+        var entity = await FindAsync<InventoryProduct>(id);
+        entity.Should().BeNull();
+    }
+}

--- a/tests/Application.UnitTests/Common/Mappings/MappingTests.cs
+++ b/tests/Application.UnitTests/Common/Mappings/MappingTests.cs
@@ -5,6 +5,8 @@ using KuyumcuStokTakip.Application.Common.Interfaces;
 using KuyumcuStokTakip.Application.Common.Models;
 using KuyumcuStokTakip.Application.TodoItems.Queries.GetTodoItemsWithPagination;
 using KuyumcuStokTakip.Application.TodoLists.Queries.GetTodos;
+using KuyumcuStokTakip.Application.InventoryProducts.Queries.GetInventoryProducts;
+using KuyumcuStokTakip.Application.Expenses.Queries.GetExpenses;
 using KuyumcuStokTakip.Domain.Entities;
 using NUnit.Framework;
 
@@ -35,6 +37,8 @@ public class MappingTests
     [TestCase(typeof(TodoList), typeof(LookupDto))]
     [TestCase(typeof(TodoItem), typeof(LookupDto))]
     [TestCase(typeof(TodoItem), typeof(TodoItemBriefDto))]
+    [TestCase(typeof(InventoryProduct), typeof(InventoryProductDto))]
+    [TestCase(typeof(Expense), typeof(ExpenseDto))]
     public void ShouldSupportMappingFromSourceToDestination(Type source, Type destination)
     {
         var instance = GetInstanceOf(source);


### PR DESCRIPTION
## Summary
- scaffold CRUD commands and queries for `InventoryProduct` and `Expense`
- expose new endpoints for these entities
- add validators and DTO mapping profiles
- extend mapping unit tests
- add basic functional tests

## Testing
- `dotnet test` *(fails: `dotnet` not found)*
- `dotnet tool run nswag run src/Web/config.nswag` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68489ec39f14832fbdc697191f665fbd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced endpoints and backend support for creating, updating, deleting, and listing expenses and inventory products, including paginated queries.
  - Added validation for required fields and data integrity when managing expenses and inventory products.
  - Implemented data transfer objects for both expenses and inventory products to standardize API responses.

- **Bug Fixes**
  - None.

- **Tests**
  - Added comprehensive tests for creating and deleting expenses and inventory products, including validation and error scenarios.
  - Expanded mapping tests to cover new data transfer objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->