### PR TITLE
Implement basic Partner CRUD features

### DIFF
--- a/src/Application/Partners/Commands/CreatePartner/CreatePartner.cs
+++ b/src/Application/Partners/Commands/CreatePartner/CreatePartner.cs
@@ -1,0 +1,41 @@
+using KuyumcuStokTakip.Application.Common.Interfaces;
+using KuyumcuStokTakip.Domain.Entities.Account;
+
+namespace KuyumcuStokTakip.Application.Partners.Commands.CreatePartner;
+
+public record CreatePartnerCommand : IRequest<int>
+{
+    public string Name { get; init; } = string.Empty;
+    public string Type { get; init; } = string.Empty;
+    public string? ParnerPhone { get; init; }
+    public string? ParnerEmail { get; init; }
+    public string? ParnerAddress { get; init; }
+    public string? Note { get; init; }
+}
+
+public class CreatePartnerCommandHandler : IRequestHandler<CreatePartnerCommand, int>
+{
+    private readonly IApplicationDbContext _context;
+
+    public CreatePartnerCommandHandler(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<int> Handle(CreatePartnerCommand request, CancellationToken cancellationToken)
+    {
+        var entity = new Partner
+        {
+            Name = request.Name,
+            Type = request.Type,
+            ParnerPhone = request.ParnerPhone,
+            ParnerEmail = request.ParnerEmail,
+            ParnerAddress = request.ParnerAddress,
+            Note = request.Note
+        };
+
+        _context.Partners.Add(entity);
+        await _context.SaveChangesAsync(cancellationToken);
+        return entity.Id;
+    }
+}

--- a/src/Application/Partners/Commands/CreatePartner/CreatePartnerCommandValidator.cs
+++ b/src/Application/Partners/Commands/CreatePartner/CreatePartnerCommandValidator.cs
@@ -1,0 +1,10 @@
+namespace KuyumcuStokTakip.Application.Partners.Commands.CreatePartner;
+
+public class CreatePartnerCommandValidator : AbstractValidator<CreatePartnerCommand>
+{
+    public CreatePartnerCommandValidator()
+    {
+        RuleFor(v => v.Name).NotEmpty();
+        RuleFor(v => v.Type).NotEmpty();
+    }
+}

--- a/src/Application/Partners/Commands/DeletePartner/DeletePartner.cs
+++ b/src/Application/Partners/Commands/DeletePartner/DeletePartner.cs
@@ -1,0 +1,24 @@
+using KuyumcuStokTakip.Application.Common.Interfaces;
+
+namespace KuyumcuStokTakip.Application.Partners.Commands.DeletePartner;
+
+public record DeletePartnerCommand(int Id) : IRequest;
+
+public class DeletePartnerCommandHandler : IRequestHandler<DeletePartnerCommand>
+{
+    private readonly IApplicationDbContext _context;
+
+    public DeletePartnerCommandHandler(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task Handle(DeletePartnerCommand request, CancellationToken cancellationToken)
+    {
+        var entity = await _context.Partners.FindAsync(new object[] { request.Id }, cancellationToken);
+        Guard.Against.NotFound(request.Id, entity);
+
+        _context.Partners.Remove(entity!);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Application/Partners/Commands/UpdatePartner/UpdatePartner.cs
+++ b/src/Application/Partners/Commands/UpdatePartner/UpdatePartner.cs
@@ -1,0 +1,39 @@
+using KuyumcuStokTakip.Application.Common.Interfaces;
+
+namespace KuyumcuStokTakip.Application.Partners.Commands.UpdatePartner;
+
+public record UpdatePartnerCommand : IRequest
+{
+    public int Id { get; init; }
+    public string Name { get; init; } = string.Empty;
+    public string Type { get; init; } = string.Empty;
+    public string? ParnerPhone { get; init; }
+    public string? ParnerEmail { get; init; }
+    public string? ParnerAddress { get; init; }
+    public string? Note { get; init; }
+}
+
+public class UpdatePartnerCommandHandler : IRequestHandler<UpdatePartnerCommand>
+{
+    private readonly IApplicationDbContext _context;
+
+    public UpdatePartnerCommandHandler(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task Handle(UpdatePartnerCommand request, CancellationToken cancellationToken)
+    {
+        var entity = await _context.Partners.FindAsync(new object[] { request.Id }, cancellationToken);
+        Guard.Against.NotFound(request.Id, entity);
+
+        entity!.Name = request.Name;
+        entity.Type = request.Type;
+        entity.ParnerPhone = request.ParnerPhone;
+        entity.ParnerEmail = request.ParnerEmail;
+        entity.ParnerAddress = request.ParnerAddress;
+        entity.Note = request.Note;
+
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Application/Partners/Commands/UpdatePartner/UpdatePartnerCommandValidator.cs
+++ b/src/Application/Partners/Commands/UpdatePartner/UpdatePartnerCommandValidator.cs
@@ -1,0 +1,11 @@
+namespace KuyumcuStokTakip.Application.Partners.Commands.UpdatePartner;
+
+public class UpdatePartnerCommandValidator : AbstractValidator<UpdatePartnerCommand>
+{
+    public UpdatePartnerCommandValidator()
+    {
+        RuleFor(v => v.Id).GreaterThan(0);
+        RuleFor(v => v.Name).NotEmpty();
+        RuleFor(v => v.Type).NotEmpty();
+    }
+}

--- a/src/Application/Partners/Queries/GetPartners/GetPartners.cs
+++ b/src/Application/Partners/Queries/GetPartners/GetPartners.cs
@@ -1,0 +1,31 @@
+using KuyumcuStokTakip.Application.Common.Interfaces;
+using KuyumcuStokTakip.Application.Common.Mappings;
+using KuyumcuStokTakip.Application.Common.Models;
+
+namespace KuyumcuStokTakip.Application.Partners.Queries.GetPartners;
+
+public record GetPartnersQuery : IRequest<PaginatedList<PartnerDto>>
+{
+    public int PageNumber { get; init; } = 1;
+    public int PageSize { get; init; } = 10;
+}
+
+public class GetPartnersQueryHandler : IRequestHandler<GetPartnersQuery, PaginatedList<PartnerDto>>
+{
+    private readonly IApplicationDbContext _context;
+    private readonly IMapper _mapper;
+
+    public GetPartnersQueryHandler(IApplicationDbContext context, IMapper mapper)
+    {
+        _context = context;
+        _mapper = mapper;
+    }
+
+    public async Task<PaginatedList<PartnerDto>> Handle(GetPartnersQuery request, CancellationToken cancellationToken)
+    {
+        return await _context.Partners
+            .OrderBy(x => x.Name)
+            .ProjectTo<PartnerDto>(_mapper.ConfigurationProvider)
+            .PaginatedListAsync(request.PageNumber, request.PageSize, cancellationToken);
+    }
+}

--- a/src/Application/Partners/Queries/GetPartners/PartnerDto.cs
+++ b/src/Application/Partners/Queries/GetPartners/PartnerDto.cs
@@ -1,0 +1,22 @@
+using KuyumcuStokTakip.Domain.Entities.Account;
+
+namespace KuyumcuStokTakip.Application.Partners.Queries.GetPartners;
+
+public class PartnerDto
+{
+    public int Id { get; init; }
+    public string Name { get; init; } = string.Empty;
+    public string Type { get; init; } = string.Empty;
+    public string? ParnerPhone { get; init; }
+    public string? ParnerEmail { get; init; }
+    public string? ParnerAddress { get; init; }
+    public string? Note { get; init; }
+
+    private class Mapping : Profile
+    {
+        public Mapping()
+        {
+            CreateMap<Partner, PartnerDto>();
+        }
+    }
+}

--- a/src/Web/Endpoints/Partners.cs
+++ b/src/Web/Endpoints/Partners.cs
@@ -1,0 +1,46 @@
+using KuyumcuStokTakip.Application.Common.Models;
+using KuyumcuStokTakip.Application.Partners.Commands.CreatePartner;
+using KuyumcuStokTakip.Application.Partners.Commands.DeletePartner;
+using KuyumcuStokTakip.Application.Partners.Commands.UpdatePartner;
+using KuyumcuStokTakip.Application.Partners.Queries.GetPartners;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace KuyumcuStokTakip.Web.Endpoints;
+
+public class Partners : EndpointGroupBase
+{
+    public override void Map(WebApplication app)
+    {
+        app.MapGroup(this)
+            .RequireAuthorization()
+            .MapGet(GetPartners)
+            .MapPost(CreatePartner)
+            .MapPut(UpdatePartner, "{id}")
+            .MapDelete(DeletePartner, "{id}");
+    }
+
+    public async Task<Ok<PaginatedList<PartnerDto>>> GetPartners(ISender sender, [AsParameters] GetPartnersQuery query)
+    {
+        var result = await sender.Send(query);
+        return TypedResults.Ok(result);
+    }
+
+    public async Task<Created<int>> CreatePartner(ISender sender, CreatePartnerCommand command)
+    {
+        var id = await sender.Send(command);
+        return TypedResults.Created($"/{nameof(Partners)}/{id}", id);
+    }
+
+    public async Task<Results<NoContent, BadRequest>> UpdatePartner(ISender sender, int id, UpdatePartnerCommand command)
+    {
+        if (id != command.Id) return TypedResults.BadRequest();
+        await sender.Send(command);
+        return TypedResults.NoContent();
+    }
+
+    public async Task<NoContent> DeletePartner(ISender sender, int id)
+    {
+        await sender.Send(new DeletePartnerCommand(id));
+        return TypedResults.NoContent();
+    }
+}

--- a/tests/Application.FunctionalTests/Partners/Commands/CreatePartnerTests.cs
+++ b/tests/Application.FunctionalTests/Partners/Commands/CreatePartnerTests.cs
@@ -1,0 +1,32 @@
+using KuyumcuStokTakip.Application.Common.Exceptions;
+using KuyumcuStokTakip.Application.Partners.Commands.CreatePartner;
+using KuyumcuStokTakip.Domain.Entities.Account;
+
+namespace KuyumcuStokTakip.Application.FunctionalTests.Partners.Commands;
+
+using static Testing;
+
+public class CreatePartnerTests : BaseTestFixture
+{
+    [Test]
+    public async Task ShouldRequireFields()
+    {
+        var command = new CreatePartnerCommand { Name = "", Type = "" };
+        await FluentActions.Invoking(() => SendAsync(command)).Should().ThrowAsync<ValidationException>();
+    }
+
+    [Test]
+    public async Task ShouldCreatePartner()
+    {
+        var command = new CreatePartnerCommand
+        {
+            Name = "Test Partner",
+            Type = "Supplier"
+        };
+
+        var id = await SendAsync(command);
+        var entity = await FindAsync<Partner>(id);
+        entity.Should().NotBeNull();
+        entity!.Name.Should().Be(command.Name);
+    }
+}

--- a/tests/Application.FunctionalTests/Partners/Commands/DeletePartnerTests.cs
+++ b/tests/Application.FunctionalTests/Partners/Commands/DeletePartnerTests.cs
@@ -1,0 +1,27 @@
+using KuyumcuStokTakip.Application.Common.Exceptions;
+using KuyumcuStokTakip.Application.Partners.Commands.CreatePartner;
+using KuyumcuStokTakip.Application.Partners.Commands.DeletePartner;
+using KuyumcuStokTakip.Domain.Entities.Account;
+
+namespace KuyumcuStokTakip.Application.FunctionalTests.Partners.Commands;
+
+using static Testing;
+
+public class DeletePartnerTests : BaseTestFixture
+{
+    [Test]
+    public async Task ShouldRequireValidId()
+    {
+        var command = new DeletePartnerCommand(99);
+        await FluentActions.Invoking(() => SendAsync(command)).Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Test]
+    public async Task ShouldDeletePartner()
+    {
+        var id = await SendAsync(new CreatePartnerCommand { Name = "Test", Type = "Supplier" });
+        await SendAsync(new DeletePartnerCommand(id));
+        var entity = await FindAsync<Partner>(id);
+        entity.Should().BeNull();
+    }
+}

--- a/tests/Application.UnitTests/Common/Mappings/MappingTests.cs
+++ b/tests/Application.UnitTests/Common/Mappings/MappingTests.cs
@@ -7,7 +7,9 @@ using KuyumcuStokTakip.Application.TodoItems.Queries.GetTodoItemsWithPagination;
 using KuyumcuStokTakip.Application.TodoLists.Queries.GetTodos;
 using KuyumcuStokTakip.Application.InventoryProducts.Queries.GetInventoryProducts;
 using KuyumcuStokTakip.Application.Expenses.Queries.GetExpenses;
+using KuyumcuStokTakip.Application.Partners.Queries.GetPartners;
 using KuyumcuStokTakip.Domain.Entities;
+using KuyumcuStokTakip.Domain.Entities.Account;
 using NUnit.Framework;
 
 namespace KuyumcuStokTakip.Application.UnitTests.Common.Mappings;
@@ -39,6 +41,7 @@ public class MappingTests
     [TestCase(typeof(TodoItem), typeof(TodoItemBriefDto))]
     [TestCase(typeof(InventoryProduct), typeof(InventoryProductDto))]
     [TestCase(typeof(Expense), typeof(ExpenseDto))]
+    [TestCase(typeof(Partner), typeof(PartnerDto))]
     public void ShouldSupportMappingFromSourceToDestination(Type source, Type destination)
     {
         var instance = GetInstanceOf(source);


### PR DESCRIPTION
## Summary
- add Partner feature with CRUD commands, queries, and validators
- expose Partner API endpoints
- include functional tests and mapping test coverage

## Testing
- `dotnet test --no-build` *(fails: command not found)*
- `npx nswag run src/Web/config.nswag` *(failed: requires interactive install)*

------
https://chatgpt.com/codex/tasks/task_e_6848a1aced00832f981e7c0f08ac7f00