### PR TITLE
Read DB connection string from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ dotnet watch run
 
 Navigate to https://localhost:5001. The application will automatically reload if you change any of the source files.
 
+## Configuration
+
+The application expects the database connection string to be supplied via the
+`KuyumcuStokTakipDb` environment variable. For example:
+
+```bash
+export KuyumcuStokTakipDb="Server=localhost,1433;Database=KuyumcuStokTakipDb;User Id=sa;Password=<your password>;TrustServerCertificate=True;"
+```
+
+Alternatively, you can set `ConnectionStrings__KuyumcuStokTakipDb` when running the application.
+
 ## Code Styles & Formatting
 
 The template includes [EditorConfig](https://editorconfig.org/) support to help maintain consistent coding styles for multiple developers working on the same project across various editors and IDEs. The **.editorconfig** file defines the coding styles applicable to this solution.

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -2,6 +2,7 @@
 using KuyumcuStokTakip.Domain.Constants;
 using KuyumcuStokTakip.Infrastructure.Data;
 using KuyumcuStokTakip.Infrastructure.Data.Interceptors;
+using System;
 using KuyumcuStokTakip.Infrastructure.Identity;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
@@ -15,7 +16,8 @@ public static class DependencyInjection
 {
     public static void AddInfrastructureServices(this IHostApplicationBuilder builder)
     {
-        var connectionString = builder.Configuration.GetConnectionString("KuyumcuStokTakipDb");
+        var connectionString = Environment.GetEnvironmentVariable("KuyumcuStokTakipDb")
+            ?? builder.Configuration.GetConnectionString("KuyumcuStokTakipDb");
         Guard.Against.Null(connectionString, message: "Connection string 'KuyumcuStokTakipDb' not found.");
 
         builder.Services.AddScoped<ISaveChangesInterceptor, AuditableEntityInterceptor>();

--- a/src/Web/appsettings.Development.json
+++ b/src/Web/appsettings.Development.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "KuyumcuStokTakipDb": "Server=localhost,1433;Database=KuyumcuStokTakipDb;User Id=sa;Password=123A.a321;TrustServerCertificate=True;"
+    "KuyumcuStokTakipDb": ""
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
## Summary
- sanitize development appsettings
- load DB connection string from environment variable if set
- document required environment variable in README

## Testing
- `dotnet test --filter 'FullyQualifiedName!~AcceptanceTests'` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849301e918c832f9d219b84fa4abf3c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a "Configuration" section to the README with instructions for setting the database connection string via environment variables.

- **Refactor**
  - Updated the application to prioritize retrieving the database connection string from an environment variable, with a fallback to the configuration file.

- **Chores**
  - Set the development configuration's database connection string to an empty value by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->