### PR TITLE
Add stock transactions feature

### DIFF
--- a/src/Web/ClientApp/src/app/app.module.ts
+++ b/src/Web/ClientApp/src/app/app.module.ts
@@ -16,6 +16,7 @@ import { ExpensesComponent } from './expenses/expenses.component';
 import { PartnersComponent } from './partners/partners.component';
 import { InventoryProductsComponent } from './inventory-products/inventory-products.component';
 import { InventoriesComponent } from './inventories/inventories.component';
+import { StockTransactionsComponent } from './stock-transactions/stock-transactions.component';
 import { AuthorizeInterceptor } from 'src/api-authorization/authorize.interceptor';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
@@ -30,7 +31,8 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
         ExpensesComponent,
         PartnersComponent,
         InventoryProductsComponent,
-        InventoriesComponent
+        InventoriesComponent,
+        StockTransactionsComponent
     ],
     bootstrap: [AppComponent],
     imports: [
@@ -44,7 +46,8 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
             { path: 'expenses', component: ExpensesComponent },
             { path: 'partners', component: PartnersComponent },
             { path: 'inventory-products', component: InventoryProductsComponent },
-            { path: 'inventories', component: InventoriesComponent }
+            { path: 'inventories', component: InventoriesComponent },
+            { path: 'stock-transactions', component: StockTransactionsComponent }
         ]),
         BrowserAnimationsModule,
         ModalModule.forRoot()],

--- a/src/Web/ClientApp/src/app/nav-menu/nav-menu.component.html
+++ b/src/Web/ClientApp/src/app/nav-menu/nav-menu.component.html
@@ -42,6 +42,9 @@
           <li class="nav-item" [routerLinkActive]="['link-active']">
             <a class="nav-link text-dark" [routerLink]="['/inventories']">Inventories</a>
           </li>
+          <li class="nav-item" [routerLinkActive]="['link-active']">
+            <a class="nav-link text-dark" [routerLink]="['/stock-transactions']">Stock Transactions</a>
+          </li>
           <li class="nav-item">
             <a class="nav-link text-dark" href="/api" target="_blank">API</a>
           </li>

--- a/src/Web/ClientApp/src/app/stock-transactions/stock-transactions.component.html
+++ b/src/Web/ClientApp/src/app/stock-transactions/stock-transactions.component.html
@@ -1,0 +1,80 @@
+<h1>Stock Transactions</h1>
+<button class="btn btn-primary mb-2 me-1" (click)="openCreateIn(editTemplate)">Giriş Yap</button>
+<button class="btn btn-secondary mb-2" (click)="openCreateOut(editTemplate)">Çıkış Yap</button>
+<table class="table table-striped" *ngIf="transactions.length">
+  <thead>
+    <tr>
+      <th>Date</th>
+      <th>Type</th>
+      <th>Quantity</th>
+      <th>Weight</th>
+      <th>Description</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    @for (t of transactions; track $index) {
+    <tr>
+      <td>{{ t.transactionDate | date:'shortDate' }}</td>
+      <td>{{ t.type === 0 ? 'Giriş' : 'Çıkış' }}</td>
+      <td>{{ t.quantity }}</td>
+      <td>{{ t.weight }}</td>
+      <td>{{ t.description }}</td>
+      <td>
+        <button class="btn btn-sm btn-secondary" (click)="openEdit(editTemplate,t)">Edit</button>
+        <button class="btn btn-sm btn-danger ms-1" (click)="confirmDelete(deleteTemplate,t)">Delete</button>
+      </td>
+    </tr>
+    }
+  </tbody>
+</table>
+
+<ng-template #editTemplate>
+  <div class="modal-header">
+    <h4 class="modal-title">{{ title }}</h4>
+    <button type="button" class="close btn-close" aria-label="Close" (click)="modalRef?.hide()"></button>
+  </div>
+  <div class="modal-body">
+    <div class="mb-2">
+      <label class="form-label">Type</label>
+      <select class="form-select" [(ngModel)]="editor.type">
+        <option [ngValue]="0">Giriş</option>
+        <option [ngValue]="1">Çıkış</option>
+      </select>
+    </div>
+    <div class="mb-2">
+      <label class="form-label">Inventory Product Id</label>
+      <input type="number" class="form-control" [(ngModel)]="editor.inventoryProductId" />
+    </div>
+    <div class="mb-2">
+      <label class="form-label">Quantity</label>
+      <input type="number" class="form-control" [(ngModel)]="editor.quantity" />
+    </div>
+    <div class="mb-2">
+      <label class="form-label">Weight</label>
+      <input type="number" class="form-control" [(ngModel)]="editor.weight" />
+    </div>
+    <div class="mb-2">
+      <label class="form-label">Description</label>
+      <input class="form-control" [(ngModel)]="editor.description" />
+    </div>
+  </div>
+  <div class="modal-footer">
+    <button class="btn btn-secondary" (click)="modalRef?.hide()">Cancel</button>
+    <button class="btn btn-primary" (click)="save()">Save</button>
+  </div>
+</ng-template>
+
+<ng-template #deleteTemplate>
+  <div class="modal-header">
+    <h4 class="modal-title">Delete Transaction?</h4>
+    <button type="button" class="close btn-close" aria-label="Close" (click)="modalRef?.hide()"></button>
+  </div>
+  <div class="modal-body">
+    Are you sure you want to delete this transaction?
+  </div>
+  <div class="modal-footer">
+    <button class="btn btn-secondary" (click)="modalRef?.hide()">Cancel</button>
+    <button class="btn btn-danger" (click)="deleteConfirmed()">Delete</button>
+  </div>
+</ng-template>

--- a/src/Web/ClientApp/src/app/stock-transactions/stock-transactions.component.spec.ts
+++ b/src/Web/ClientApp/src/app/stock-transactions/stock-transactions.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { StockTransactionsComponent } from './stock-transactions.component';
+
+describe('StockTransactionsComponent', () => {
+  let fixture: ComponentFixture<StockTransactionsComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [StockTransactionsComponent]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(StockTransactionsComponent);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+});

--- a/src/Web/ClientApp/src/app/stock-transactions/stock-transactions.component.ts
+++ b/src/Web/ClientApp/src/app/stock-transactions/stock-transactions.component.ts
@@ -1,0 +1,78 @@
+import { Component, OnInit, TemplateRef } from '@angular/core';
+import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
+import { StockTransactionsClient, StockTransactionDto, CreateStockTransactionCommand, UpdateStockTransactionCommand } from '../web-api-client';
+
+@Component({
+  selector: 'app-stock-transactions',
+  templateUrl: './stock-transactions.component.html'
+})
+export class StockTransactionsComponent implements OnInit {
+  transactions: StockTransactionDto[] = [];
+  selected?: StockTransactionDto;
+  editor: any = {};
+  modalRef?: BsModalRef;
+  title = '';
+
+  constructor(private client: StockTransactionsClient, private modalService: BsModalService) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.client.getStockTransactions(1, 10).subscribe({
+      next: r => this.transactions = r.items,
+      error: err => console.error(err)
+    });
+  }
+
+  openCreateIn(template: TemplateRef<any>): void {
+    this.title = 'New Giriş Transaction';
+    this.selected = undefined;
+    this.editor = { type: 0 };
+    this.modalRef = this.modalService.show(template);
+  }
+
+  openCreateOut(template: TemplateRef<any>): void {
+    this.title = 'New Çıkış Transaction';
+    this.selected = undefined;
+    this.editor = { type: 1 };
+    this.modalRef = this.modalService.show(template);
+  }
+
+  openEdit(template: TemplateRef<any>, item: StockTransactionDto): void {
+    this.title = 'Edit Transaction';
+    this.selected = item;
+    this.editor = { ...item };
+    this.modalRef = this.modalService.show(template);
+  }
+
+  save(): void {
+    if (this.selected) {
+      const cmd: UpdateStockTransactionCommand = { id: this.selected.id, ...this.editor };
+      this.client.updateStockTransaction(this.selected.id, cmd).subscribe({
+        next: () => { this.modalRef?.hide(); this.load(); },
+        error: err => console.error(err)
+      });
+    } else {
+      const cmd: CreateStockTransactionCommand = { ...this.editor };
+      this.client.createStockTransaction(cmd).subscribe({
+        next: () => { this.modalRef?.hide(); this.load(); },
+        error: err => console.error(err)
+      });
+    }
+  }
+
+  confirmDelete(template: TemplateRef<any>, item: StockTransactionDto): void {
+    this.selected = item;
+    this.modalRef = this.modalService.show(template);
+  }
+
+  deleteConfirmed(): void {
+    if (!this.selected) return;
+    this.client.deleteStockTransaction(this.selected.id).subscribe({
+      next: () => { this.modalRef?.hide(); this.load(); },
+      error: err => console.error(err)
+    });
+  }
+}

--- a/src/Web/ClientApp/src/app/web-api-client.ts
+++ b/src/Web/ClientApp/src/app/web-api-client.ts
@@ -1278,3 +1278,14 @@ export class InventoriesClient {
     updateInventory(id: number, command: UpdateInventoryCommand): Observable<void> { return _observableOf(undefined); }
     deleteInventory(id: number): Observable<void> { return _observableOf(undefined); }
 }
+
+export interface StockTransactionDto { [key: string]: any; id?: number; }
+export interface CreateStockTransactionCommand { [key: string]: any; }
+export interface UpdateStockTransactionCommand { id: number; [key: string]: any; }
+@Injectable({ providedIn: 'root' })
+export class StockTransactionsClient {
+    getStockTransactions(pageNumber: number, pageSize: number): Observable<any> { return _observableOf({ items: [] }); }
+    createStockTransaction(command: CreateStockTransactionCommand): Observable<number> { return _observableOf(0); }
+    updateStockTransaction(id: number, command: UpdateStockTransactionCommand): Observable<void> { return _observableOf(undefined); }
+    deleteStockTransaction(id: number): Observable<void> { return _observableOf(undefined); }
+}


### PR DESCRIPTION
## Summary
- add stock-transactions component and spec
- stub StockTransactionsClient in web-api-client.ts
- register StockTransactionsComponent and route
- add navigation link for Stock Transactions

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68493199e560832fba8fdcc9e355c490

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a Stock Transactions page for managing inbound ("Giriş") and outbound ("Çıkış") stock transactions, accessible from the navigation menu.
  - Users can view, create, edit, and delete stock transactions through a user-friendly interface with modal dialogs.
- **Tests**
  - Added unit tests to ensure the Stock Transactions component functions correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->