### PR TITLE
Add StockTransactions endpoint

### DIFF
--- a/src/Web/Endpoints/StockTransactions.cs
+++ b/src/Web/Endpoints/StockTransactions.cs
@@ -1,0 +1,47 @@
+using KuyumcuStokTakip.Application.Common.Models;
+using KuyumcuStokTakip.Application.StockTransactions.Commands.CreateStockTransaction;
+using KuyumcuStokTakip.Application.StockTransactions.Commands.DeleteStockTransaction;
+using KuyumcuStokTakip.Application.StockTransactions.Commands.UpdateStockTransaction;
+using KuyumcuStokTakip.Application.StockTransactions.Queries.GetStockTransactions;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace KuyumcuStokTakip.Web.Endpoints;
+
+public class StockTransactions : EndpointGroupBase
+{
+    public override void Map(WebApplication app)
+    {
+        app.MapGroup(this)
+            .RequireAuthorization()
+            .MapGet(GetStockTransactions)
+            .MapPost(CreateStockTransaction)
+            .MapPut(UpdateStockTransaction, "{id}")
+            .MapDelete(DeleteStockTransaction, "{id}");
+    }
+
+    public async Task<Ok<PaginatedList<StockTransactionDto>>> GetStockTransactions(ISender sender, [AsParameters] GetStockTransactionsQuery query)
+    {
+        var result = await sender.Send(query);
+        return TypedResults.Ok(result);
+    }
+
+    public async Task<Created<int>> CreateStockTransaction(ISender sender, CreateStockTransactionCommand command)
+    {
+        var id = await sender.Send(command);
+        return TypedResults.Created($"/{nameof(StockTransactions)}/{id}", id);
+    }
+
+    public async Task<Results<NoContent, BadRequest>> UpdateStockTransaction(ISender sender, int id, UpdateStockTransactionCommand command)
+    {
+        if (id != command.Id) return TypedResults.BadRequest();
+        await sender.Send(command);
+        return TypedResults.NoContent();
+    }
+
+    public async Task<NoContent> DeleteStockTransaction(ISender sender, int id)
+    {
+        await sender.Send(new DeleteStockTransactionCommand(id));
+        return TypedResults.NoContent();
+    }
+}
+


### PR DESCRIPTION
## Summary
- wire up StockTransactions endpoint group
- add GET/POST/PUT/DELETE mappings for stock transactions

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*
- `dotnet test --filter 'FullyQualifiedName!~AcceptanceTests'` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684937728504832fb4feb1146b354d19