### PR TITLE
Add stock transaction tests

### DIFF
--- a/tests/Application.FunctionalTests/CustomWebApplicationFactory.cs
+++ b/tests/Application.FunctionalTests/CustomWebApplicationFactory.cs
@@ -8,6 +8,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.AspNetCore.Authentication;
 
 namespace KuyumcuStokTakip.Application.FunctionalTests;
 
@@ -38,6 +39,14 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
                     options.AddInterceptors(sp.GetServices<ISaveChangesInterceptor>());
                     options.UseSqlServer(_connection);
                 });
+
+            services.AddAuthentication("Test")
+                .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>("Test", options => { });
+            services.PostConfigureAll<AuthenticationOptions>(options =>
+            {
+                options.DefaultAuthenticateScheme = "Test";
+                options.DefaultChallengeScheme = "Test";
+            });
         });
     }
 }

--- a/tests/Application.FunctionalTests/StockTransactions/Endpoints/StockTransactionsEndpointTests.cs
+++ b/tests/Application.FunctionalTests/StockTransactions/Endpoints/StockTransactionsEndpointTests.cs
@@ -1,0 +1,87 @@
+using System.Net.Http.Json;
+using KuyumcuStokTakip.Application.StockTransactions.Commands.CreateStockTransaction;
+using KuyumcuStokTakip.Application.StockTransactions.Commands.UpdateStockTransaction;
+using KuyumcuStokTakip.Domain.Entities.Inventory;
+
+namespace KuyumcuStokTakip.Application.FunctionalTests.StockTransactions.Endpoints;
+
+using static Testing;
+
+public class StockTransactionsEndpointTests : BaseTestFixture
+{
+    [Test]
+    public async Task ShouldCreateStockTransaction()
+    {
+        await RunAsDefaultUserAsync();
+        var client = CreateClient();
+        var command = new CreateStockTransactionCommand
+        {
+            InventoryProductId = 1,
+            Quantity = 1,
+            Weight = 1,
+            UnitPriceType = EUnitPriceType.Milyem,
+            Type = EStockTransactionType.In
+        };
+
+        var response = await client.PostAsJsonAsync("/api/StockTransactions", command);
+        response.EnsureSuccessStatusCode();
+        var id = await response.Content.ReadFromJsonAsync<int>();
+
+        var entity = await FindAsync<StockTransaction>(id);
+        entity.Should().NotBeNull();
+        entity!.InventoryProductId.Should().Be(command.InventoryProductId);
+    }
+
+    [Test]
+    public async Task ShouldUpdateStockTransaction()
+    {
+        await RunAsDefaultUserAsync();
+        var client = CreateClient();
+        var id = await SendAsync(new CreateStockTransactionCommand
+        {
+            InventoryProductId = 1,
+            Quantity = 1,
+            Weight = 1,
+            UnitPriceType = EUnitPriceType.Milyem,
+            Type = EStockTransactionType.In
+        });
+
+        var update = new UpdateStockTransactionCommand
+        {
+            Id = id,
+            InventoryProductId = 1,
+            Quantity = 2,
+            Weight = 2,
+            UnitPriceType = EUnitPriceType.Milyem,
+            Type = EStockTransactionType.Out
+        };
+
+        var response = await client.PutAsJsonAsync($"/api/StockTransactions/{id}", update);
+        response.EnsureSuccessStatusCode();
+
+        var entity = await FindAsync<StockTransaction>(id);
+        entity!.Quantity.Should().Be(update.Quantity);
+        entity.Type.Should().Be(update.Type);
+    }
+
+    [Test]
+    public async Task ShouldDeleteStockTransaction()
+    {
+        await RunAsDefaultUserAsync();
+        var client = CreateClient();
+        var id = await SendAsync(new CreateStockTransactionCommand
+        {
+            InventoryProductId = 1,
+            Quantity = 1,
+            Weight = 1,
+            UnitPriceType = EUnitPriceType.Milyem,
+            Type = EStockTransactionType.In
+        });
+
+        var response = await client.DeleteAsync($"/api/StockTransactions/{id}");
+        response.EnsureSuccessStatusCode();
+
+        var entity = await FindAsync<StockTransaction>(id);
+        entity.Should().BeNull();
+    }
+}

--- a/tests/Application.FunctionalTests/TestAuthHandler.cs
+++ b/tests/Application.FunctionalTests/TestAuthHandler.cs
@@ -1,0 +1,29 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace KuyumcuStokTakip.Application.FunctionalTests;
+
+public class TestAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    public TestAuthHandler(IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock)
+        : base(options, logger, encoder, clock)
+    {
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        var claims = new[]
+        {
+            new Claim(ClaimTypes.NameIdentifier, Testing.GetUserId() ?? "test-user"),
+            new Claim(ClaimTypes.Name, "test-user")
+        };
+        var identity = new ClaimsIdentity(claims, "Test");
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, "Test");
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/tests/Application.FunctionalTests/Testing.cs
+++ b/tests/Application.FunctionalTests/Testing.cs
@@ -5,6 +5,7 @@ using MediatR;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using System.Net.Http;
 
 namespace KuyumcuStokTakip.Application.FunctionalTests;
 
@@ -135,6 +136,11 @@ public partial class Testing
         var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
         return await context.Set<TEntity>().CountAsync();
+    }
+
+    public static HttpClient CreateClient()
+    {
+        return _factory.CreateClient();
     }
 
     [OneTimeTearDown]

--- a/tests/Application.UnitTests/StockTransactions/Commands/StockTransactionCommandHandlerTests.cs
+++ b/tests/Application.UnitTests/StockTransactions/Commands/StockTransactionCommandHandlerTests.cs
@@ -1,0 +1,89 @@
+using KuyumcuStokTakip.Application.StockTransactions.Commands.CreateStockTransaction;
+using KuyumcuStokTakip.Application.StockTransactions.Commands.DeleteStockTransaction;
+using KuyumcuStokTakip.Application.StockTransactions.Commands.UpdateStockTransaction;
+using KuyumcuStokTakip.Domain.Entities.Inventory;
+using KuyumcuStokTakip.Application.Common.Interfaces;
+using Moq;
+using NUnit.Framework;
+using Microsoft.EntityFrameworkCore;
+
+namespace KuyumcuStokTakip.Application.UnitTests.StockTransactions.Commands;
+
+public class StockTransactionCommandHandlerTests
+{
+    private Mock<IApplicationDbContext> _context = null!;
+    private Mock<DbSet<StockTransaction>> _dbSet = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _context = new Mock<IApplicationDbContext>();
+        _dbSet = new Mock<DbSet<StockTransaction>>();
+        _context.SetupGet(c => c.StockTransactions).Returns(_dbSet.Object);
+        _context.Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+    }
+
+    [Test]
+    public async Task CreateHandlerAddsEntity()
+    {
+        var handler = new CreateStockTransactionCommandHandler(_context.Object);
+        var command = new CreateStockTransactionCommand
+        {
+            InventoryProductId = 1,
+            Quantity = 1,
+            Weight = 1,
+            UnitPriceType = EUnitPriceType.Milyem,
+            Type = EStockTransactionType.In
+        };
+
+        await handler.Handle(command, CancellationToken.None);
+
+        _dbSet.Verify(d => d.Add(It.IsAny<StockTransaction>()), Times.Once);
+        _context.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task UpdateHandlerUpdatesEntity()
+    {
+        var entity = new StockTransaction { Id = 1 };
+        var dbSet = new Mock<DbSet<StockTransaction>>();
+        dbSet.Setup(d => d.FindAsync(new object[] { 1 }, It.IsAny<CancellationToken>())).ReturnsAsync(entity);
+        _context.SetupGet(c => c.StockTransactions).Returns(dbSet.Object);
+
+        var handler = new UpdateStockTransactionCommandHandler(_context.Object);
+        var command = new UpdateStockTransactionCommand
+        {
+            Id = 1,
+            InventoryProductId = 1,
+            Quantity = 2,
+            Weight = 2,
+            UnitPriceType = EUnitPriceType.Milyem,
+            Type = EStockTransactionType.Out
+        };
+
+        await handler.Handle(command, CancellationToken.None);
+
+        dbSet.Verify(d => d.FindAsync(new object[] { 1 }, It.IsAny<CancellationToken>()), Times.Once);
+        _context.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        Assert.AreEqual(2, entity.Quantity);
+        Assert.AreEqual(EStockTransactionType.Out, entity.Type);
+    }
+
+    [Test]
+    public async Task DeleteHandlerRemovesEntity()
+    {
+        var entity = new StockTransaction { Id = 1 };
+        var dbSet = new Mock<DbSet<StockTransaction>>();
+        dbSet.Setup(d => d.FindAsync(new object[] { 1 }, It.IsAny<CancellationToken>())).ReturnsAsync(entity);
+        _context.SetupGet(c => c.StockTransactions).Returns(dbSet.Object);
+
+        var handler = new DeleteStockTransactionCommandHandler(_context.Object);
+        var command = new DeleteStockTransactionCommand(1);
+
+        await handler.Handle(command, CancellationToken.None);
+
+        dbSet.Verify(d => d.FindAsync(new object[] { 1 }, It.IsAny<CancellationToken>()), Times.Once);
+        _context.Verify(c => c.StockTransactions.Remove(entity), Times.Once);
+        _context.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/tests/Web.AcceptanceTests/Features/StockTransactions.feature
+++ b/tests/Web.AcceptanceTests/Features/StockTransactions.feature
@@ -1,0 +1,8 @@
+@StockTransactions
+Feature: Stock Transactions
+    Create stock entries via the web UI
+
+    Scenario: Add new stock transaction
+        Given the user is on the stock transactions page
+        When the user creates a stock entry
+        Then the stock entry is visible

--- a/tests/Web.AcceptanceTests/Pages/StockTransactionsPage.cs
+++ b/tests/Web.AcceptanceTests/Pages/StockTransactionsPage.cs
@@ -1,0 +1,24 @@
+namespace KuyumcuStokTakip.Web.AcceptanceTests.Pages;
+
+public class StockTransactionsPage : BasePage
+{
+    public StockTransactionsPage(IBrowser browser, IPage page)
+    {
+        Browser = browser;
+        Page = page;
+    }
+
+    public override string PagePath => $"{BaseUrl}/stock-transactions";
+
+    public override IBrowser Browser { get; }
+
+    public override IPage Page { get; set; }
+
+    public Task ClickNewIn() => Page.GetByText("Giriş Yap").ClickAsync();
+    public Task FillInventoryProductId(string value) => Page.Locator("input[ngmodel='editor.inventoryProductId']").FillAsync(value);
+    public Task FillQuantity(string value) => Page.Locator("input[ngmodel='editor.quantity']").FillAsync(value);
+    public Task FillWeight(string value) => Page.Locator("input[ngmodel='editor.weight']").FillAsync(value);
+    public Task FillDescription(string value) => Page.Locator("input[ngmodel='editor.description']").FillAsync(value);
+    public Task Save() => Page.GetByText("Save").ClickAsync();
+    public Task<bool> TransactionExists(string description) => Page.Locator($"text={description}").IsVisibleAsync();
+}

--- a/tests/Web.AcceptanceTests/StepDefinitions/StockTransactionsStepDefinitions.cs
+++ b/tests/Web.AcceptanceTests/StepDefinitions/StockTransactionsStepDefinitions.cs
@@ -1,0 +1,57 @@
+namespace KuyumcuStokTakip.Web.AcceptanceTests.StepDefinitions;
+
+[Binding]
+public sealed class StockTransactionsStepDefinitions
+{
+    private readonly StockTransactionsPage _page;
+
+    public StockTransactionsStepDefinitions(StockTransactionsPage page)
+    {
+        _page = page;
+    }
+
+    [BeforeFeature("StockTransactions")]
+    public static async Task BeforeScenario(IObjectContainer container)
+    {
+        var playwright = await Playwright.CreateAsync();
+        var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions());
+        var page = await browser.NewPageAsync();
+        var stockPage = new StockTransactionsPage(browser, page);
+        container.RegisterInstanceAs(playwright);
+        container.RegisterInstanceAs(browser);
+        container.RegisterInstanceAs(stockPage);
+    }
+
+    [Given("the user is on the stock transactions page")]
+    public async Task GivenTheUserIsOnTheStockTransactionsPage()
+    {
+        await _page.GotoAsync();
+    }
+
+    [When("the user creates a stock entry")]
+    public async Task WhenTheUserCreatesAStockEntry()
+    {
+        await _page.ClickNewIn();
+        await _page.FillInventoryProductId("1");
+        await _page.FillQuantity("1");
+        await _page.FillWeight("1");
+        await _page.FillDescription("ui test");
+        await _page.Save();
+    }
+
+    [Then("the stock entry is visible")]
+    public async Task ThenTheStockEntryIsVisible()
+    {
+        var exists = await _page.TransactionExists("ui test");
+        exists.Should().BeTrue();
+    }
+
+    [AfterFeature]
+    public static async Task AfterScenario(IObjectContainer container)
+    {
+        var browser = container.Resolve<IBrowser>();
+        var playwright = container.Resolve<IPlaywright>();
+        await browser.CloseAsync();
+        playwright.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary
- add test authentication handler for API integration tests
- expose test `CreateClient` helper
- cover stock transactions endpoints
- unit test stock transaction command handlers
- start a Playwright UI test for creating stock transactions

## Testing
- `dotnet test KuyumcuStokTakip.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68493b7f4f98832f9b4785e226cf8105