### PR TITLE
Add Sale transaction type

### DIFF
--- a/src/Application/StockTransactions/Commands/CreateStockTransaction/CreateStockTransaction.cs
+++ b/src/Application/StockTransactions/Commands/CreateStockTransaction/CreateStockTransaction.cs
@@ -1,6 +1,7 @@
 using KuyumcuStokTakip.Application.Common.Interfaces;
 using KuyumcuStokTakip.Domain.Entities;
 using KuyumcuStokTakip.Domain.Entities.Inventory;
+using KuyumcuStokTakip.Domain.Enums;
 
 namespace KuyumcuStokTakip.Application.StockTransactions.Commands.CreateStockTransaction;
 

--- a/src/Application/StockTransactions/Commands/UpdateStockTransaction/UpdateStockTransaction.cs
+++ b/src/Application/StockTransactions/Commands/UpdateStockTransaction/UpdateStockTransaction.cs
@@ -1,6 +1,7 @@
 using KuyumcuStokTakip.Application.Common.Interfaces;
 using KuyumcuStokTakip.Domain.Entities;
 using KuyumcuStokTakip.Domain.Entities.Inventory;
+using KuyumcuStokTakip.Domain.Enums;
 
 namespace KuyumcuStokTakip.Application.StockTransactions.Commands.UpdateStockTransaction;
 

--- a/src/Domain/Enums/TransactionType.cs
+++ b/src/Domain/Enums/TransactionType.cs
@@ -3,5 +3,6 @@ namespace KuyumcuStokTakip.Domain.Enums;
 public enum TransactionType
 {
     Purchase = 0,
-    ManualAdjustment = 1
+    ManualAdjustment = 1,
+    Sale = 2
 }

--- a/src/Web/ClientApp/src/app/stock-transactions/stock-transactions.component.html
+++ b/src/Web/ClientApp/src/app/stock-transactions/stock-transactions.component.html
@@ -16,7 +16,9 @@
     @for (t of transactions; track $index) {
     <tr>
       <td>{{ t.transactionDate | date:'shortDate' }}</td>
-      <td>{{ t.transactionType === 0 ? 'Purchase' : 'Manual Adjustment' }}</td>
+      <td>
+        {{ t.transactionType === 0 ? 'Purchase' : t.transactionType === 1 ? 'Manual Adjustment' : 'Sale' }}
+      </td>
       <td>{{ t.pureGram }}</td>
       <td>{{ t.unitPrice }}</td>
       <td>{{ t.description }}</td>
@@ -40,6 +42,7 @@
       <select class="form-select" [(ngModel)]="editor.transactionType">
         <option [ngValue]="0">Purchase</option>
         <option [ngValue]="1">Manual Adjustment</option>
+        <option [ngValue]="2">Sale</option>
       </select>
     </div>
     <div class="mb-2">

--- a/src/Web/ClientApp/src/app/web-api-client.ts
+++ b/src/Web/ClientApp/src/app/web-api-client.ts
@@ -3478,6 +3478,7 @@ export enum ETransactionSourceType {
 export enum TransactionType {
     Purchase = 0,
     ManualAdjustment = 1,
+    Sale = 2,
 }
 
 export enum ProductKind {

--- a/src/Web/wwwroot/api/specification.json
+++ b/src/Web/wwwroot/api/specification.json
@@ -1693,11 +1693,13 @@
         "description": "",
         "x-enumNames": [
           "Purchase",
-          "ManualAdjustment"
+          "ManualAdjustment",
+          "Sale"
         ],
         "enum": [
           0,
-          1
+          1,
+          2
         ]
       },
       "CreateStockTransactionCommand": {

--- a/tests/Application.FunctionalTests/StockTransactions/Endpoints/StockTransactionsEndpointTests.cs
+++ b/tests/Application.FunctionalTests/StockTransactions/Endpoints/StockTransactionsEndpointTests.cs
@@ -2,6 +2,7 @@ using System.Net.Http.Json;
 using KuyumcuStokTakip.Application.StockTransactions.Commands.CreateStockTransaction;
 using KuyumcuStokTakip.Application.StockTransactions.Commands.UpdateStockTransaction;
 using KuyumcuStokTakip.Domain.Entities.Inventory;
+using KuyumcuStokTakip.Domain.Entities;
 using KuyumcuStokTakip.Domain.Enums;
 
 namespace KuyumcuStokTakip.Application.FunctionalTests.StockTransactions.Endpoints;

--- a/tests/Application.FunctionalTests/TestAuthHandler.cs
+++ b/tests/Application.FunctionalTests/TestAuthHandler.cs
@@ -8,11 +8,13 @@ namespace KuyumcuStokTakip.Application.FunctionalTests;
 
 public class TestAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
 {
+#pragma warning disable CS0618 // ISystemClock is obsolete
     public TestAuthHandler(IOptionsMonitor<AuthenticationSchemeOptions> options,
         ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock)
         : base(options, logger, encoder, clock)
     {
     }
+#pragma warning restore CS0618
 
     protected override Task<AuthenticateResult> HandleAuthenticateAsync()
     {

--- a/tests/Application.UnitTests/Common/Mappings/MappingTests.cs
+++ b/tests/Application.UnitTests/Common/Mappings/MappingTests.cs
@@ -10,6 +10,8 @@ using KuyumcuStokTakip.Application.Expenses.Queries.GetExpenses;
 using KuyumcuStokTakip.Application.Partners.Queries.GetPartners;
 using KuyumcuStokTakip.Domain.Entities;
 using KuyumcuStokTakip.Domain.Entities.Account;
+using KuyumcuStokTakip.Domain.Entities.Inventory;
+using KuyumcuStokTakip.Domain.Entities.Finance;
 using NUnit.Framework;
 
 namespace KuyumcuStokTakip.Application.UnitTests.Common.Mappings;

--- a/tests/Application.UnitTests/StockTransactions/Commands/StockTransactionCommandHandlerTests.cs
+++ b/tests/Application.UnitTests/StockTransactions/Commands/StockTransactionCommandHandlerTests.cs
@@ -2,6 +2,7 @@ using KuyumcuStokTakip.Application.StockTransactions.Commands.CreateStockTransac
 using KuyumcuStokTakip.Application.StockTransactions.Commands.DeleteStockTransaction;
 using KuyumcuStokTakip.Application.StockTransactions.Commands.UpdateStockTransaction;
 using KuyumcuStokTakip.Domain.Entities.Inventory;
+using KuyumcuStokTakip.Domain.Entities;
 using KuyumcuStokTakip.Domain.Enums;
 using KuyumcuStokTakip.Application.Common.Interfaces;
 using Moq;
@@ -70,8 +71,8 @@ public class StockTransactionCommandHandlerTests
 
         dbSet.Verify(d => d.FindAsync(new object[] { 1 }, It.IsAny<CancellationToken>()), Times.Once);
         _context.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
-        Assert.AreEqual(2, entity.Quantity);
-        Assert.AreEqual(EStockTransactionType.Out, entity.Type);
+        Assert.That(entity.Quantity, Is.EqualTo(2));
+        Assert.That(entity.Type, Is.EqualTo(EStockTransactionType.Out));
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- add `Sale` to `TransactionType` enum
- update Web client enums and UI to reflect new value
- include new enum option in API specification
- fix namespace usages in tests
- replace classic NUnit assertions
- suppress obsolete warning in test auth handler

## Testing
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6849770f24b4832fa750a05374269637

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for a new "Sale" transaction type throughout the application, including transaction creation, editing, and display.
  - Updated transaction type dropdowns and transaction lists to include and show the "Sale" option.

- **Documentation**
  - Updated API specification to reflect the addition of the "Sale" transaction type.

- **Tests**
  - Improved test coverage and style to support the new transaction type and updated assertion formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->