### PR TITLE
Implement CreateSaleCommand

### DIFF
--- a/src/Application/Sales/Commands/CreateSale/CreateSaleCommand.cs
+++ b/src/Application/Sales/Commands/CreateSale/CreateSaleCommand.cs
@@ -1,0 +1,74 @@
+using KuyumcuStokTakip.Application.Common.Interfaces;
+using KuyumcuStokTakip.Domain.Entities.Inventory;
+using KuyumcuStokTakip.Domain.Entities.Sales;
+using KuyumcuStokTakip.Domain.Enums;
+using KuyumcuStokTakip.Domain.Entities;
+
+namespace KuyumcuStokTakip.Application.Sales.Commands.CreateSale;
+
+public record CreateSaleCommand : IRequest<int>
+{
+    public DateTime SaleDate { get; init; } = DateTime.UtcNow;
+    public int? CustomerId { get; init; }
+    public IList<SaleItemDto> Items { get; init; } = new List<SaleItemDto>();
+
+    public record SaleItemDto
+    {
+        public int? ProductItemId { get; init; }
+        public int? InventoryProductId { get; init; }
+        public decimal Quantity { get; init; }
+        public decimal UnitPrice { get; init; }
+    }
+}
+
+public class CreateSaleCommandHandler : IRequestHandler<CreateSaleCommand, int>
+{
+    private readonly IApplicationDbContext _context;
+
+    public CreateSaleCommandHandler(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<int> Handle(CreateSaleCommand request, CancellationToken cancellationToken)
+    {
+        var sale = new Sale
+        {
+            SaleDate = request.SaleDate,
+            CustomerId = request.CustomerId
+        };
+
+        foreach (var item in request.Items)
+        {
+            var saleItem = new SaleItem
+            {
+                ProductItemId = item.ProductItemId,
+                InventoryProductId = item.InventoryProductId,
+                Quantity = item.Quantity,
+                UnitPrice = item.UnitPrice
+            };
+            sale.Items.Add(saleItem);
+
+            if (item.InventoryProductId.HasValue)
+            {
+                var transaction = new StockTransaction
+                {
+                    InventoryProductId = item.InventoryProductId.Value,
+                    ProductItemId = item.ProductItemId,
+                    ProductId = item.InventoryProductId.Value,
+                    TransactionDate = request.SaleDate,
+                    Quantity = item.Quantity,
+                    UnitPrice = item.UnitPrice,
+                    TransactionType = TransactionType.Sale,
+                    Type = EStockTransactionType.Out
+                };
+                _context.StockTransactions.Add(transaction);
+            }
+        }
+
+        _context.Sales.Add(sale);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return sale.Id;
+    }
+}

--- a/src/Application/Sales/Commands/CreateSale/CreateSaleCommandValidator.cs
+++ b/src/Application/Sales/Commands/CreateSale/CreateSaleCommandValidator.cs
@@ -1,0 +1,14 @@
+namespace KuyumcuStokTakip.Application.Sales.Commands.CreateSale;
+
+public class CreateSaleCommandValidator : AbstractValidator<CreateSaleCommand>
+{
+    public CreateSaleCommandValidator()
+    {
+        RuleFor(v => v.Items).NotEmpty();
+        RuleForEach(v => v.Items).ChildRules(items =>
+        {
+            items.RuleFor(i => i.Quantity).GreaterThan(0);
+            items.RuleFor(i => i.UnitPrice).GreaterThanOrEqualTo(0);
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add `CreateSaleCommand` with nested item DTO
- implement command handler creating `Sale`, `SaleItem`, and related stock transactions
- add command validator checking items and positive quantity/price

## Testing
- `dotnet build KuyumcuStokTakip.sln -c Release`
- `dotnet test KuyumcuStokTakip.sln` *(fails: Testcontainers.MsSql.MsSqlBuilder.Validate)*

------
https://chatgpt.com/codex/tasks/task_e_68497ae956b8832fb537279bf891152a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to create new sales records, including specifying sale date, customer, and multiple sale items.
  - Automatically records stock outflow transactions for items linked to inventory products during sale creation.

- **Bug Fixes**
  - Added validation to ensure that sales include at least one item, and that each item's quantity and unit price meet minimum requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->