### PR TITLE
Add sales functional tests

### DIFF
--- a/tests/Application.FunctionalTests/Sales/Commands/CreateSaleTests.cs
+++ b/tests/Application.FunctionalTests/Sales/Commands/CreateSaleTests.cs
@@ -1,0 +1,50 @@
+using KuyumcuStokTakip.Application.Common.Exceptions;
+using KuyumcuStokTakip.Application.Sales.Commands.CreateSale;
+using KuyumcuStokTakip.Domain.Entities.Inventory;
+using KuyumcuStokTakip.Domain.Entities.Sales;
+
+namespace KuyumcuStokTakip.Application.FunctionalTests.Sales.Commands;
+
+using static Testing;
+
+public class CreateSaleTests : BaseTestFixture
+{
+    [Test]
+    public async Task ShouldRequireFields()
+    {
+        var command = new CreateSaleCommand();
+        await FluentActions.Invoking(() => SendAsync(command))
+            .Should().ThrowAsync<ValidationException>();
+
+        command = new CreateSaleCommand
+        {
+            Items = [ new CreateSaleCommand.SaleItemDto { Quantity = 0, UnitPrice = -1 } ]
+        };
+        await FluentActions.Invoking(() => SendAsync(command))
+            .Should().ThrowAsync<ValidationException>();
+    }
+
+    [Test]
+    public async Task ShouldCreateSaleAndStockTransactions()
+    {
+        var before = await CountAsync<StockTransaction>();
+
+        var command = new CreateSaleCommand
+        {
+            Items = [ new CreateSaleCommand.SaleItemDto
+            {
+                InventoryProductId = 1,
+                Quantity = 1,
+                UnitPrice = 100
+            }]
+        };
+
+        var id = await SendAsync(command);
+
+        var sale = await FindAsync<Sale>(id);
+        sale.Should().NotBeNull();
+
+        var after = await CountAsync<StockTransaction>();
+        after.Should().Be(before + 1);
+    }
+}


### PR DESCRIPTION
## Summary
- add Sales functional test folder with `CreateSaleTests`
- add endpoint tests for creating sales

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684985368f1c832fa11e9f4864b996c6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added new tests to verify validation and successful creation of sales, including checks for required fields and stock transaction updates.
  - Introduced an end-to-end test for the sales creation API endpoint, ensuring proper sale creation and stock transaction recording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->