### PR TITLE
Add sale retrieval query and tests

### DIFF
--- a/src/Application/Sales/Queries/GetSaleById/GetSaleById.cs
+++ b/src/Application/Sales/Queries/GetSaleById/GetSaleById.cs
@@ -1,0 +1,26 @@
+using KuyumcuStokTakip.Application.Common.Interfaces;
+using KuyumcuStokTakip.Application.Sales.Queries.GetSales;
+
+namespace KuyumcuStokTakip.Application.Sales.Queries.GetSaleById;
+
+public record GetSaleByIdQuery(int Id) : IRequest<SaleDto>;
+
+public class GetSaleByIdQueryHandler : IRequestHandler<GetSaleByIdQuery, SaleDto>
+{
+    private readonly IApplicationDbContext _context;
+    private readonly IMapper _mapper;
+
+    public GetSaleByIdQueryHandler(IApplicationDbContext context, IMapper mapper)
+    {
+        _context = context;
+        _mapper = mapper;
+    }
+
+    public async Task<SaleDto> Handle(GetSaleByIdQuery request, CancellationToken cancellationToken)
+    {
+        return await _context.Sales
+            .Where(x => x.Id == request.Id)
+            .ProjectTo<SaleDto>(_mapper.ConfigurationProvider)
+            .FirstAsync(cancellationToken);
+    }
+}

--- a/src/Web/Endpoints/Sales.cs
+++ b/src/Web/Endpoints/Sales.cs
@@ -1,6 +1,7 @@
 using KuyumcuStokTakip.Application.Common.Models;
 using KuyumcuStokTakip.Application.Sales.Commands.CreateSale;
 using KuyumcuStokTakip.Application.Sales.Queries.GetSales;
+using KuyumcuStokTakip.Application.Sales.Queries.GetSaleById;
 using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace KuyumcuStokTakip.Web.Endpoints;
@@ -12,12 +13,19 @@ public class Sales : EndpointGroupBase
         app.MapGroup(this)
             .RequireAuthorization()
             .MapGet(GetSales)
+            .MapGet(GetSale, "{id}")
             .MapPost(CreateSale);
     }
 
     public async Task<Ok<PaginatedList<SaleDto>>> GetSales(ISender sender, [AsParameters] GetSalesQuery query)
     {
         var result = await sender.Send(query);
+        return TypedResults.Ok(result);
+    }
+
+    public async Task<Ok<SaleDto>> GetSale(ISender sender, int id)
+    {
+        var result = await sender.Send(new GetSaleByIdQuery(id));
         return TypedResults.Ok(result);
     }
 

--- a/tests/Application.FunctionalTests/Sales/Endpoints/SalesEndpointTests.cs
+++ b/tests/Application.FunctionalTests/Sales/Endpoints/SalesEndpointTests.cs
@@ -1,7 +1,9 @@
 using System.Net.Http.Json;
 using KuyumcuStokTakip.Application.Sales.Commands.CreateSale;
+using KuyumcuStokTakip.Application.Sales.Queries.GetSaleById;
 using KuyumcuStokTakip.Domain.Entities.Inventory;
 using KuyumcuStokTakip.Domain.Entities.Sales;
+using KuyumcuStokTakip.Application.Sales.Queries.GetSales;
 
 namespace KuyumcuStokTakip.Application.FunctionalTests.Sales.Endpoints;
 
@@ -34,5 +36,29 @@ public class SalesEndpointTests : BaseTestFixture
 
         var after = await CountAsync<StockTransaction>();
         after.Should().Be(before + 1);
+    }
+
+    [Test]
+    public async Task ShouldGetSale()
+    {
+        await RunAsDefaultUserAsync();
+        var client = CreateClient();
+
+        var saleId = await SendAsync(new CreateSaleCommand
+        {
+            Items = [ new CreateSaleCommand.SaleItemDto
+            {
+                InventoryProductId = 1,
+                Quantity = 1,
+                UnitPrice = 100
+            }]
+        });
+
+        var response = await client.GetAsync($"/api/Sales/{saleId}");
+        response.EnsureSuccessStatusCode();
+        var sale = await response.Content.ReadFromJsonAsync<SaleDto>();
+
+        sale.Should().NotBeNull();
+        sale!.Id.Should().Be(saleId);
     }
 }

--- a/tests/Application.FunctionalTests/Sales/Queries/GetSaleByIdTests.cs
+++ b/tests/Application.FunctionalTests/Sales/Queries/GetSaleByIdTests.cs
@@ -1,0 +1,31 @@
+using KuyumcuStokTakip.Application.Sales.Commands.CreateSale;
+using KuyumcuStokTakip.Application.Sales.Queries.GetSaleById;
+
+namespace KuyumcuStokTakip.Application.FunctionalTests.Sales.Queries;
+
+using static Testing;
+
+public class GetSaleByIdTests : BaseTestFixture
+{
+    [Test]
+    public async Task ShouldReturnSale()
+    {
+        await RunAsDefaultUserAsync();
+
+        var saleId = await SendAsync(new CreateSaleCommand
+        {
+            Items = [ new CreateSaleCommand.SaleItemDto
+            {
+                InventoryProductId = 1,
+                Quantity = 1,
+                UnitPrice = 100
+            }]
+        });
+
+        var query = new GetSaleByIdQuery(saleId);
+        var result = await SendAsync(query);
+
+        result.Should().NotBeNull();
+        result.Id.Should().Be(saleId);
+    }
+}


### PR DESCRIPTION
## Summary
- add GetSaleById query and handler
- expose GET `/api/Sales/{id}` endpoint
- test retrieval via query and endpoint

## Testing
- `dotnet test KuyumcuStokTakip.sln --no-build -v minimal` *(fails: Playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68498ce63a50832faeb7743aa85af130

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an endpoint to retrieve a specific sale by its ID.
- **Tests**
  - Introduced new tests to verify the retrieval of a sale by ID through the API and query layer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->