### PR TITLE
Set customer id for sale stock transactions

### DIFF
--- a/src/Application/Sales/Commands/CreateSale/CreateSaleCommand.cs
+++ b/src/Application/Sales/Commands/CreateSale/CreateSaleCommand.cs
@@ -56,6 +56,7 @@ public class CreateSaleCommandHandler : IRequestHandler<CreateSaleCommand, int>
                     InventoryProductId = item.InventoryProductId.Value,
                     ProductItemId = item.ProductItemId,
                     ProductId = item.InventoryProductId.Value,
+                    CustomerId = request.CustomerId,
                     TransactionDate = request.SaleDate,
                     Quantity = item.Quantity,
                     UnitPrice = item.UnitPrice,

--- a/tests/Application.FunctionalTests/Sales/Commands/CreateSaleTests.cs
+++ b/tests/Application.FunctionalTests/Sales/Commands/CreateSaleTests.cs
@@ -1,5 +1,6 @@
 using KuyumcuStokTakip.Application.Common.Exceptions;
 using KuyumcuStokTakip.Application.Sales.Commands.CreateSale;
+using KuyumcuStokTakip.Application.Customers.Commands.CreateCustomer;
 using KuyumcuStokTakip.Domain.Entities.Inventory;
 using KuyumcuStokTakip.Domain.Entities.Sales;
 
@@ -29,8 +30,15 @@ public class CreateSaleTests : BaseTestFixture
     {
         var before = await CountAsync<StockTransaction>();
 
+        var customerId = await SendAsync(new CreateCustomerCommand
+        {
+            FirstName = "Jane",
+            LastName = "Doe"
+        });
+
         var command = new CreateSaleCommand
         {
+            CustomerId = customerId,
             Items = [ new CreateSaleCommand.SaleItemDto
             {
                 InventoryProductId = 1,
@@ -46,5 +54,9 @@ public class CreateSaleTests : BaseTestFixture
 
         var after = await CountAsync<StockTransaction>();
         after.Should().Be(before + 1);
+
+        var transaction = await FindAsync<StockTransaction>(after);
+        transaction.Should().NotBeNull();
+        transaction!.CustomerId.Should().Be(customerId);
     }
 }


### PR DESCRIPTION
## Summary
- populate `CustomerId` when creating a sale's `StockTransaction`
- ensure functional test checks stored customer id

## Testing
- `dotnet test --filter 'FullyQualifiedName!~AcceptanceTests' --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d2164cf0832faab388c0eafb7cdc