### PR TITLE
Add GetSales functional test

### DIFF
--- a/tests/Application.FunctionalTests/Sales/Queries/GetSalesTests.cs
+++ b/tests/Application.FunctionalTests/Sales/Queries/GetSalesTests.cs
@@ -1,0 +1,40 @@
+using KuyumcuStokTakip.Application.Customers.Commands.CreateCustomer;
+using KuyumcuStokTakip.Application.Sales.Commands.CreateSale;
+using KuyumcuStokTakip.Application.Sales.Common;
+using KuyumcuStokTakip.Application.Sales.Queries.GetSales;
+
+namespace KuyumcuStokTakip.Application.FunctionalTests.Sales.Queries;
+
+using static Testing;
+
+public class GetSalesTests : BaseTestFixture
+{
+    [Test]
+    public async Task ShouldReturnCreatedSale()
+    {
+        await RunAsDefaultUserAsync();
+
+        var customerId = await SendAsync(new CreateCustomerCommand
+        {
+            FirstName = "John",
+            LastName = "Doe"
+        });
+
+        var saleId = await SendAsync(new CreateSaleCommand
+        {
+            CustomerId = customerId,
+            Items = [ new SaleItemDto
+            {
+                InventoryProductId = 1,
+                Quantity = 2,
+                UnitPrice = 100
+            }]
+        });
+
+        var result = await SendAsync(new GetSalesQuery());
+
+        var sale = result.Items.First(s => s.Id == saleId);
+        sale.CustomerName.Should().Be("John Doe");
+        sale.TotalAmount.Should().Be(200);
+    }
+}


### PR DESCRIPTION
## Summary
- add functional test to verify GetSalesQuery returns created sale with customer name and total amount

## Testing
- `dotnet test tests/Application.FunctionalTests/Application.FunctionalTests.csproj --filter "FullyQualifiedName~GetSalesTests" -v minimal` *(fails: Docker not running)*

------
https://chatgpt.com/codex/tasks/task_e_6849db3e3520832fa5d9870d97126a64