### PR TITLE
Add stock balance query and UI

### DIFF
--- a/src/Application/StockBalances/Queries/GetStockBalance/GetStockBalanceQuery.cs
+++ b/src/Application/StockBalances/Queries/GetStockBalance/GetStockBalanceQuery.cs
@@ -1,0 +1,37 @@
+using KuyumcuStokTakip.Application.Common.Interfaces;
+using KuyumcuStokTakip.Domain.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace KuyumcuStokTakip.Application.StockBalances.Queries.GetStockBalance;
+
+public record GetStockBalanceQuery : IRequest<List<StockBalanceDto>>;
+
+public class GetStockBalanceQueryHandler : IRequestHandler<GetStockBalanceQuery, List<StockBalanceDto>>
+{
+    private readonly IApplicationDbContext _context;
+
+    public GetStockBalanceQueryHandler(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<List<StockBalanceDto>> Handle(GetStockBalanceQuery request, CancellationToken cancellationToken)
+    {
+        return await _context.StockTransactions
+            .Include(t => t.InventoryProduct)
+            .GroupBy(t => new { t.InventoryProductId, t.InventoryProduct.Name })
+            .Select(g => new StockBalanceDto
+            {
+                InventoryProductId = g.Key.InventoryProductId,
+                ProductName = g.Key.Name,
+                TotalIn = g.Where(t => t.Type == EStockTransactionType.In).Sum(t => t.Quantity),
+                TotalOut = g.Where(t => t.Type == EStockTransactionType.Out).Sum(t => t.Quantity),
+                NetQuantity = g.Where(t => t.Type == EStockTransactionType.In).Sum(t => t.Quantity) -
+                              g.Where(t => t.Type == EStockTransactionType.Out).Sum(t => t.Quantity)
+            })
+            .OrderBy(x => x.InventoryProductId)
+            .ToListAsync(cancellationToken);
+    }
+}
+

--- a/src/Application/StockBalances/Queries/GetStockBalance/StockBalanceDto.cs
+++ b/src/Application/StockBalances/Queries/GetStockBalance/StockBalanceDto.cs
@@ -1,0 +1,13 @@
+using KuyumcuStokTakip.Domain.Entities.Inventory;
+using KuyumcuStokTakip.Domain.Entities;
+
+namespace KuyumcuStokTakip.Application.StockBalances.Queries.GetStockBalance;
+
+public class StockBalanceDto
+{
+    public int InventoryProductId { get; init; }
+    public string ProductName { get; init; } = string.Empty;
+    public decimal TotalIn { get; init; }
+    public decimal TotalOut { get; init; }
+    public decimal NetQuantity { get; init; }
+}

--- a/src/Web/ClientApp/src/app/app.module.ts
+++ b/src/Web/ClientApp/src/app/app.module.ts
@@ -20,6 +20,7 @@ import { StockTransactionsComponent } from './stock-transactions/stock-transacti
 import { ProductsComponent } from './products/products.component';
 import { CustomersComponent } from './customers/customers.component';
 import { SalesComponent } from './sales/sales.component';
+import { StockBalanceComponent } from './stock-balance/stock-balance.component';
 import { AuthorizeInterceptor } from 'src/api-authorization/authorize.interceptor';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
@@ -38,6 +39,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
         StockTransactionsComponent,
         ProductsComponent,
         CustomersComponent,
+        StockBalanceComponent,
         SalesComponent
     ],
     bootstrap: [AppComponent],
@@ -57,6 +59,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
             { path: 'stock-transactions', component: StockTransactionsComponent },
             { path: 'products', component: ProductsComponent },
             { path: 'customers', component: CustomersComponent },
+            { path: 'stock-balance', component: StockBalanceComponent },
             { path: 'sales', component: SalesComponent }
         ]),
         BrowserAnimationsModule,

--- a/src/Web/ClientApp/src/app/nav-menu/nav-menu.component.html
+++ b/src/Web/ClientApp/src/app/nav-menu/nav-menu.component.html
@@ -52,6 +52,9 @@
             <a class="nav-link text-dark" [routerLink]="['/customers']">Customers</a>
           </li>
           <li class="nav-item" [routerLinkActive]="['link-active']">
+            <a class="nav-link text-dark" [routerLink]="['/stock-balance']">Stock Balance</a>
+          </li>
+          <li class="nav-item" [routerLinkActive]="['link-active']">
             <a class="nav-link text-dark" [routerLink]="['/sales']">Sales</a>
           </li>
           <li class="nav-item">

--- a/src/Web/ClientApp/src/app/stock-balance/stock-balance.component.html
+++ b/src/Web/ClientApp/src/app/stock-balance/stock-balance.component.html
@@ -1,0 +1,19 @@
+<h1>Stock Balance</h1>
+<table class="table table-striped" *ngIf="balances.length">
+  <thead>
+    <tr>
+      <th>Product</th>
+      <th>Total In</th>
+      <th>Total Out</th>
+      <th>Net Quantity</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr *ngFor="let b of balances">
+      <td>{{ b.productName }}</td>
+      <td>{{ b.totalIn }}</td>
+      <td>{{ b.totalOut }}</td>
+      <td>{{ b.netQuantity }}</td>
+    </tr>
+  </tbody>
+</table>

--- a/src/Web/ClientApp/src/app/stock-balance/stock-balance.component.spec.ts
+++ b/src/Web/ClientApp/src/app/stock-balance/stock-balance.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { StockBalanceComponent } from './stock-balance.component';
+
+describe('StockBalanceComponent', () => {
+  let fixture: ComponentFixture<StockBalanceComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [StockBalanceComponent]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(StockBalanceComponent);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+});

--- a/src/Web/ClientApp/src/app/stock-balance/stock-balance.component.ts
+++ b/src/Web/ClientApp/src/app/stock-balance/stock-balance.component.ts
@@ -1,0 +1,23 @@
+import { Component, OnInit } from '@angular/core';
+import { StockBalancesClient, StockBalanceDto } from '../web-api-client';
+
+@Component({
+  selector: 'app-stock-balance',
+  templateUrl: './stock-balance.component.html'
+})
+export class StockBalanceComponent implements OnInit {
+  balances: StockBalanceDto[] = [];
+
+  constructor(private client: StockBalancesClient) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.client.getStockBalances().subscribe({
+      next: r => (this.balances = r),
+      error: err => console.error(err)
+    });
+  }
+}

--- a/src/Web/Endpoints/StockBalances.cs
+++ b/src/Web/Endpoints/StockBalances.cs
@@ -1,0 +1,21 @@
+using KuyumcuStokTakip.Application.StockBalances.Queries.GetStockBalance;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace KuyumcuStokTakip.Web.Endpoints;
+
+public class StockBalances : EndpointGroupBase
+{
+    public override void Map(WebApplication app)
+    {
+        app.MapGroup(this)
+            .RequireAuthorization()
+            .MapGet(GetStockBalances);
+    }
+
+    public async Task<Ok<List<StockBalanceDto>>> GetStockBalances(ISender sender)
+    {
+        var result = await sender.Send(new GetStockBalanceQuery());
+        return TypedResults.Ok(result);
+    }
+}
+

--- a/src/Web/wwwroot/api/specification.json
+++ b/src/Web/wwwroot/api/specification.json
@@ -1296,6 +1296,27 @@
         }
       }
     },
+    "/api/StockBalances": {
+      "get": {
+        "tags": [
+          "StockBalances"
+        ],
+        "operationId": "GetStockBalances",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/StockBalanceDto" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/WeatherForecasts": {
       "get": {
         "tags": [
@@ -2770,6 +2791,17 @@
           }
         }
       },
+        "StockBalanceDto": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "inventoryProductId": { "type": "integer", "format": "int32" },
+            "productName": { "type": "string" },
+            "totalIn": { "type": "number", "format": "decimal" },
+            "totalOut": { "type": "number", "format": "decimal" },
+            "netQuantity": { "type": "number", "format": "decimal" }
+          }
+        },
       "WeatherForecast": {
         "type": "object",
         "additionalProperties": false,

--- a/tests/Application.FunctionalTests/StockBalances/Queries/GetStockBalanceTests.cs
+++ b/tests/Application.FunctionalTests/StockBalances/Queries/GetStockBalanceTests.cs
@@ -1,0 +1,47 @@
+using KuyumcuStokTakip.Application.StockTransactions.Commands.CreateStockTransaction;
+using KuyumcuStokTakip.Application.StockBalances.Queries.GetStockBalance;
+using KuyumcuStokTakip.Domain.Enums;
+using System.Linq;
+
+namespace KuyumcuStokTakip.Application.FunctionalTests.StockBalances.Queries;
+
+using static Testing;
+
+public class GetStockBalanceTests : BaseTestFixture
+{
+    [Test]
+    public async Task ShouldReturnCorrectSums()
+    {
+        await RunAsDefaultUserAsync();
+
+        await SendAsync(new CreateStockTransactionCommand
+        {
+            InventoryProductId = 1,
+            ProductId = 1,
+            Quantity = 5,
+            Weight = 5,
+            UnitPriceType = EUnitPriceType.Milyem,
+            Type = EStockTransactionType.In,
+            TransactionType = TransactionType.Purchase
+        });
+
+        await SendAsync(new CreateStockTransactionCommand
+        {
+            InventoryProductId = 1,
+            ProductId = 1,
+            Quantity = 2,
+            Weight = 2,
+            UnitPriceType = EUnitPriceType.Milyem,
+            Type = EStockTransactionType.Out,
+            TransactionType = TransactionType.ManualAdjustment
+        });
+
+        var result = await SendAsync(new GetStockBalanceQuery());
+        var balance = result.First(x => x.InventoryProductId == 1);
+
+        balance.TotalIn.Should().Be(5);
+        balance.TotalOut.Should().Be(2);
+        balance.NetQuantity.Should().Be(3);
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement StockBalance application query and handler
- expose StockBalances endpoint and OpenAPI schema
- add Angular client and component for stock balances
- include functional test for stock balance logic

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849df31dde0832f8878fbbfd90700fb