### PR TITLE
Add profit calculation for sales

### DIFF
--- a/src/Application/Sales/Common/SaleItemDto.cs
+++ b/src/Application/Sales/Common/SaleItemDto.cs
@@ -11,6 +11,7 @@ public class SaleItemDto
     public decimal Quantity { get; init; }
     public decimal UnitPrice { get; init; }
     public decimal Total { get; init; }
+    public decimal? Profit { get; set; }
 
     private class Mapping : Profile
     {

--- a/src/Application/Sales/Queries/GetSaleById/GetSaleById.cs
+++ b/src/Application/Sales/Queries/GetSaleById/GetSaleById.cs
@@ -1,5 +1,6 @@
 using KuyumcuStokTakip.Application.Common.Interfaces;
 using KuyumcuStokTakip.Application.Sales.Queries.GetSales;
+using KuyumcuStokTakip.Domain.Entities;
 
 namespace KuyumcuStokTakip.Application.Sales.Queries.GetSaleById;
 
@@ -18,9 +19,32 @@ public class GetSaleByIdQueryHandler : IRequestHandler<GetSaleByIdQuery, SaleDto
 
     public async Task<SaleDto> Handle(GetSaleByIdQuery request, CancellationToken cancellationToken)
     {
-        return await _context.Sales
+        var sale = await _context.Sales
             .Where(x => x.Id == request.Id)
             .ProjectTo<SaleDto>(_mapper.ConfigurationProvider)
             .FirstAsync(cancellationToken);
+
+        await AddProfitAsync(sale.Items, cancellationToken);
+
+        return sale;
+    }
+
+    private async Task AddProfitAsync(IEnumerable<Common.SaleItemDto> items, CancellationToken cancellationToken)
+    {
+        foreach (var item in items)
+        {
+            if (!item.InventoryProductId.HasValue)
+                continue;
+
+            var avgPurchasePrice = await _context.StockTransactions
+                .Where(t => t.InventoryProductId == item.InventoryProductId.Value && t.Type == EStockTransactionType.In)
+                .Select(t => (decimal?)t.UnitPrice)
+                .AverageAsync(cancellationToken);
+
+            if (avgPurchasePrice.HasValue)
+            {
+                item.Profit = (item.UnitPrice - avgPurchasePrice.Value) * item.Quantity;
+            }
+        }
     }
 }

--- a/src/Application/Sales/Queries/GetSales/GetSales.cs
+++ b/src/Application/Sales/Queries/GetSales/GetSales.cs
@@ -1,6 +1,7 @@
 using KuyumcuStokTakip.Application.Common.Interfaces;
 using KuyumcuStokTakip.Application.Common.Mappings;
 using KuyumcuStokTakip.Application.Common.Models;
+using KuyumcuStokTakip.Domain.Entities;
 
 namespace KuyumcuStokTakip.Application.Sales.Queries.GetSales;
 
@@ -23,9 +24,35 @@ public class GetSalesQueryHandler : IRequestHandler<GetSalesQuery, PaginatedList
 
     public async Task<PaginatedList<SaleDto>> Handle(GetSalesQuery request, CancellationToken cancellationToken)
     {
-        return await _context.Sales
+        var list = await _context.Sales
             .OrderByDescending(x => x.SaleDate)
             .ProjectTo<SaleDto>(_mapper.ConfigurationProvider)
             .PaginatedListAsync(request.PageNumber, request.PageSize, cancellationToken);
+
+        foreach (var sale in list.Items)
+        {
+            await AddProfitAsync(sale.Items, cancellationToken);
+        }
+
+        return list;
+    }
+
+    private async Task AddProfitAsync(IEnumerable<Common.SaleItemDto> items, CancellationToken cancellationToken)
+    {
+        foreach (var item in items)
+        {
+            if (!item.InventoryProductId.HasValue)
+                continue;
+
+            var avgPurchasePrice = await _context.StockTransactions
+                .Where(t => t.InventoryProductId == item.InventoryProductId.Value && t.Type == EStockTransactionType.In)
+                .Select(t => (decimal?)t.UnitPrice)
+                .AverageAsync(cancellationToken);
+
+            if (avgPurchasePrice.HasValue)
+            {
+                item.Profit = (item.UnitPrice - avgPurchasePrice.Value) * item.Quantity;
+            }
+        }
     }
 }

--- a/src/Web/ClientApp/src/app/web-api-client.ts
+++ b/src/Web/ClientApp/src/app/web-api-client.ts
@@ -3876,6 +3876,7 @@ export class SaleItemDto implements ISaleItemDto {
     quantity?: number;
     unitPrice?: number;
     total?: number;
+    profit?: number | undefined;
 
     constructor(data?: ISaleItemDto) {
         if (data) {
@@ -3894,6 +3895,7 @@ export class SaleItemDto implements ISaleItemDto {
             this.quantity = _data["quantity"];
             this.unitPrice = _data["unitPrice"];
             this.total = _data["total"];
+            this.profit = _data["profit"];
         }
     }
 
@@ -3912,6 +3914,7 @@ export class SaleItemDto implements ISaleItemDto {
         data["quantity"] = this.quantity;
         data["unitPrice"] = this.unitPrice;
         data["total"] = this.total;
+        data["profit"] = this.profit;
         return data;
     }
 }
@@ -3923,6 +3926,7 @@ export interface ISaleItemDto {
     quantity?: number;
     unitPrice?: number;
     total?: number;
+    profit?: number | undefined;
 }
 
 export class CreateSaleCommand implements ICreateSaleCommand {

--- a/src/Web/wwwroot/api/specification.json
+++ b/src/Web/wwwroot/api/specification.json
@@ -2186,6 +2186,11 @@
           "total": {
             "type": "number",
             "format": "decimal"
+          },
+          "profit": {
+            "type": "number",
+            "format": "decimal",
+            "nullable": true
           }
         }
       },

--- a/tests/Application.FunctionalTests/Sales/Queries/GetSaleByIdTests.cs
+++ b/tests/Application.FunctionalTests/Sales/Queries/GetSaleByIdTests.cs
@@ -1,6 +1,10 @@
 using KuyumcuStokTakip.Application.Sales.Commands.CreateSale;
 using KuyumcuStokTakip.Application.Sales.Common;
 using KuyumcuStokTakip.Application.Sales.Queries.GetSaleById;
+using KuyumcuStokTakip.Application.StockTransactions.Commands.CreateStockTransaction;
+using KuyumcuStokTakip.Application.StockTransactions.Queries.GetStockTransactions;
+using KuyumcuStokTakip.Domain.Entities;
+using KuyumcuStokTakip.Domain.Enums;
 
 namespace KuyumcuStokTakip.Application.FunctionalTests.Sales.Queries;
 
@@ -28,5 +32,53 @@ public class GetSaleByIdTests : BaseTestFixture
 
         result.Should().NotBeNull();
         result.Id.Should().Be(saleId);
+    }
+
+    [Test]
+    public async Task ShouldCalculateProfit()
+    {
+        await RunAsDefaultUserAsync();
+
+        await SendAsync(new CreateStockTransactionCommand
+        {
+            InventoryProductId = 1,
+            ProductId = 1,
+            Quantity = 1,
+            Weight = 1,
+            UnitPrice = 50,
+            UnitPriceType = EUnitPriceType.TL,
+            Type = EStockTransactionType.In,
+            TransactionType = TransactionType.Purchase
+        });
+
+        await SendAsync(new CreateStockTransactionCommand
+        {
+            InventoryProductId = 1,
+            ProductId = 1,
+            Quantity = 1,
+            Weight = 1,
+            UnitPrice = 100,
+            UnitPriceType = EUnitPriceType.TL,
+            Type = EStockTransactionType.In,
+            TransactionType = TransactionType.Purchase
+        });
+
+        var saleId = await SendAsync(new CreateSaleCommand
+        {
+            Items = [ new SaleItemDto
+            {
+                InventoryProductId = 1,
+                Quantity = 2,
+                UnitPrice = 120
+            }]
+        });
+
+        var transactions = await SendAsync(new GetStockTransactionsQuery { PageSize = 50 });
+        var avg = transactions.Items.Where(t => t.InventoryProductId == 1 && t.Type == EStockTransactionType.In).Average(t => t.UnitPrice);
+
+        var result = await SendAsync(new GetSaleByIdQuery(saleId));
+        var profit = result.Items.First().Profit;
+
+        profit.Should().Be((120 - avg) * 2);
     }
 }

--- a/tests/Application.FunctionalTests/Sales/Queries/GetSalesTests.cs
+++ b/tests/Application.FunctionalTests/Sales/Queries/GetSalesTests.cs
@@ -2,6 +2,10 @@ using KuyumcuStokTakip.Application.Customers.Commands.CreateCustomer;
 using KuyumcuStokTakip.Application.Sales.Commands.CreateSale;
 using KuyumcuStokTakip.Application.Sales.Common;
 using KuyumcuStokTakip.Application.Sales.Queries.GetSales;
+using KuyumcuStokTakip.Application.StockTransactions.Commands.CreateStockTransaction;
+using KuyumcuStokTakip.Application.StockTransactions.Queries.GetStockTransactions;
+using KuyumcuStokTakip.Domain.Entities;
+using KuyumcuStokTakip.Domain.Enums;
 
 namespace KuyumcuStokTakip.Application.FunctionalTests.Sales.Queries;
 
@@ -36,5 +40,53 @@ public class GetSalesTests : BaseTestFixture
         var sale = result.Items.First(s => s.Id == saleId);
         sale.CustomerName.Should().Be("John Doe");
         sale.TotalAmount.Should().Be(200);
+    }
+
+    [Test]
+    public async Task ShouldReturnProfit()
+    {
+        await RunAsDefaultUserAsync();
+
+        await SendAsync(new CreateStockTransactionCommand
+        {
+            InventoryProductId = 1,
+            ProductId = 1,
+            Quantity = 1,
+            Weight = 1,
+            UnitPrice = 50,
+            UnitPriceType = EUnitPriceType.TL,
+            Type = EStockTransactionType.In,
+            TransactionType = TransactionType.Purchase
+        });
+
+        await SendAsync(new CreateStockTransactionCommand
+        {
+            InventoryProductId = 1,
+            ProductId = 1,
+            Quantity = 1,
+            Weight = 1,
+            UnitPrice = 100,
+            UnitPriceType = EUnitPriceType.TL,
+            Type = EStockTransactionType.In,
+            TransactionType = TransactionType.Purchase
+        });
+
+        var saleId = await SendAsync(new CreateSaleCommand
+        {
+            Items = [ new SaleItemDto
+            {
+                InventoryProductId = 1,
+                Quantity = 2,
+                UnitPrice = 120
+            }]
+        });
+
+        var transactions = await SendAsync(new GetStockTransactionsQuery { PageSize = 50 });
+        var avg = transactions.Items.Where(t => t.InventoryProductId == 1 && t.Type == EStockTransactionType.In).Average(t => t.UnitPrice);
+
+        var result = await SendAsync(new GetSalesQuery());
+        var sale = result.Items.First(s => s.Id == saleId);
+
+        sale.Items.First().Profit.Should().Be((120 - avg) * 2);
     }
 }


### PR DESCRIPTION
## Summary
- extend `SaleItemDto` with `Profit`
- compute profit in sales query handlers using stock transactions
- expose new property in OpenAPI spec and TypeScript client
- test profit calculations for sales queries

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e2ebb520832f859d18b367ad738b