### PR TITLE
Add sales query filtering

### DIFF
--- a/src/Application/Sales/Queries/GetSales/GetSales.cs
+++ b/src/Application/Sales/Queries/GetSales/GetSales.cs
@@ -2,6 +2,7 @@ using KuyumcuStokTakip.Application.Common.Interfaces;
 using KuyumcuStokTakip.Application.Common.Mappings;
 using KuyumcuStokTakip.Application.Common.Models;
 using KuyumcuStokTakip.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
 
 namespace KuyumcuStokTakip.Application.Sales.Queries.GetSales;
 
@@ -9,6 +10,11 @@ public record GetSalesQuery : IRequest<PaginatedList<SaleDto>>
 {
     public int PageNumber { get; init; } = 1;
     public int PageSize { get; init; } = 10;
+
+    public DateTime? StartDate { get; init; }
+    public DateTime? EndDate { get; init; }
+    public string? CustomerName { get; init; }
+    public int? CategoryId { get; init; }
 }
 
 public class GetSalesQueryHandler : IRequestHandler<GetSalesQuery, PaginatedList<SaleDto>>
@@ -24,7 +30,31 @@ public class GetSalesQueryHandler : IRequestHandler<GetSalesQuery, PaginatedList
 
     public async Task<PaginatedList<SaleDto>> Handle(GetSalesQuery request, CancellationToken cancellationToken)
     {
-        var list = await _context.Sales
+        var query = _context.Sales.AsQueryable();
+
+        if (request.StartDate.HasValue)
+        {
+            query = query.Where(s => s.SaleDate >= request.StartDate.Value);
+        }
+
+        if (request.EndDate.HasValue)
+        {
+            query = query.Where(s => s.SaleDate <= request.EndDate.Value);
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.CustomerName))
+        {
+            var term = request.CustomerName.ToLower();
+            query = query.Where(s => s.Customer != null &&
+                EF.Functions.Like((s.Customer.FirstName + " " + s.Customer.LastName).ToLower(), $"%{term}%"));
+        }
+
+        if (request.CategoryId.HasValue)
+        {
+            query = query.Where(s => s.Items.Any(i => i.InventoryProduct != null && i.InventoryProduct.CategoryId == request.CategoryId.Value));
+        }
+
+        var list = await query
             .OrderByDescending(x => x.SaleDate)
             .ProjectTo<SaleDto>(_mapper.ConfigurationProvider)
             .PaginatedListAsync(request.PageNumber, request.PageSize, cancellationToken);

--- a/src/Web/ClientApp/src/app/sales/sales.component.ts
+++ b/src/Web/ClientApp/src/app/sales/sales.component.ts
@@ -56,7 +56,7 @@ export class SalesComponent implements OnInit {
   }
 
   load(): void {
-    this.salesClient.getSales(1, 50).subscribe({
+    this.salesClient.getSales(undefined, undefined, undefined, undefined, 1, 50).subscribe({
       next: r => (this.sales = r.items ?? []),
       error: err => console.error(err)
     });

--- a/src/Web/ClientApp/src/app/web-api-client.ts
+++ b/src/Web/ClientApp/src/app/web-api-client.ts
@@ -1298,7 +1298,7 @@ export class ProductsClient implements IProductsClient {
 }
 
 export interface ISalesClient {
-    getSales(pageNumber: number, pageSize: number): Observable<PaginatedListOfSaleDto>;
+    getSales(startDate: Date | null | undefined, endDate: Date | null | undefined, customerName: string | null | undefined, categoryId: number | null | undefined, pageNumber: number, pageSize: number): Observable<PaginatedListOfSaleDto>;
     createSale(command: CreateSaleCommand): Observable<number>;
     getSale(id: number): Observable<SaleDto>;
 }
@@ -1316,8 +1316,16 @@ export class SalesClient implements ISalesClient {
         this.baseUrl = baseUrl ?? "";
     }
 
-    getSales(pageNumber: number, pageSize: number): Observable<PaginatedListOfSaleDto> {
+    getSales(startDate: Date | null | undefined, endDate: Date | null | undefined, customerName: string | null | undefined, categoryId: number | null | undefined, pageNumber: number, pageSize: number): Observable<PaginatedListOfSaleDto> {
         let url_ = this.baseUrl + "/api/Sales?";
+        if (startDate !== undefined && startDate !== null)
+            url_ += "StartDate=" + encodeURIComponent(startDate.toISOString()) + "&";
+        if (endDate !== undefined && endDate !== null)
+            url_ += "EndDate=" + encodeURIComponent(endDate.toISOString()) + "&";
+        if (customerName !== undefined && customerName !== null)
+            url_ += "CustomerName=" + encodeURIComponent("" + customerName) + "&";
+        if (categoryId !== undefined && categoryId !== null)
+            url_ += "CategoryId=" + encodeURIComponent("" + categoryId) + "&";
         if (pageNumber === undefined || pageNumber === null)
             throw new Error("The parameter 'pageNumber' must be defined and cannot be null.");
         else

--- a/src/Web/wwwroot/api/specification.json
+++ b/src/Web/wwwroot/api/specification.json
@@ -763,24 +763,42 @@
         "operationId": "GetSales",
         "parameters": [
           {
+            "name": "StartDate",
+            "in": "query",
+            "schema": { "type": "string", "format": "date-time", "nullable": true },
+            "x-position": 1
+          },
+          {
+            "name": "EndDate",
+            "in": "query",
+            "schema": { "type": "string", "format": "date-time", "nullable": true },
+            "x-position": 2
+          },
+          {
+            "name": "CustomerName",
+            "in": "query",
+            "schema": { "type": "string", "nullable": true },
+            "x-position": 3
+          },
+          {
+            "name": "CategoryId",
+            "in": "query",
+            "schema": { "type": "integer", "format": "int32", "nullable": true },
+            "x-position": 4
+          },
+          {
             "name": "PageNumber",
             "in": "query",
             "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "x-position": 1
+            "schema": { "type": "integer", "format": "int32" },
+            "x-position": 5
           },
           {
             "name": "PageSize",
             "in": "query",
             "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "x-position": 2
+            "schema": { "type": "integer", "format": "int32" },
+            "x-position": 6
           }
         ],
         "responses": {

--- a/tests/Application.FunctionalTests/Sales/Queries/GetSalesTests.cs
+++ b/tests/Application.FunctionalTests/Sales/Queries/GetSalesTests.cs
@@ -4,6 +4,7 @@ using KuyumcuStokTakip.Application.Sales.Common;
 using KuyumcuStokTakip.Application.Sales.Queries.GetSales;
 using KuyumcuStokTakip.Application.StockTransactions.Commands.CreateStockTransaction;
 using KuyumcuStokTakip.Application.StockTransactions.Queries.GetStockTransactions;
+using KuyumcuStokTakip.Application.InventoryProducts.Commands.CreateInventoryProduct;
 using KuyumcuStokTakip.Domain.Entities;
 using KuyumcuStokTakip.Domain.Enums;
 
@@ -88,5 +89,89 @@ public class GetSalesTests : BaseTestFixture
         var sale = result.Items.First(s => s.Id == saleId);
 
         sale.Items.First().Profit.Should().Be((120 - avg) * 2);
+    }
+
+    [Test]
+    public async Task ShouldFilterByDate()
+    {
+        await RunAsDefaultUserAsync();
+
+        var oldSaleId = await SendAsync(new CreateSaleCommand
+        {
+            SaleDate = DateTime.UtcNow.AddDays(-5),
+            Items = [ new SaleItemDto { InventoryProductId = 1, Quantity = 1, UnitPrice = 50 } ]
+        });
+
+        var recentSaleId = await SendAsync(new CreateSaleCommand
+        {
+            SaleDate = DateTime.UtcNow,
+            Items = [ new SaleItemDto { InventoryProductId = 1, Quantity = 1, UnitPrice = 60 } ]
+        });
+
+        var result = await SendAsync(new GetSalesQuery
+        {
+            StartDate = DateTime.UtcNow.AddDays(-1),
+            EndDate = DateTime.UtcNow.AddDays(1)
+        });
+
+        result.Items.Should().ContainSingle(s => s.Id == recentSaleId);
+        result.Items.Should().NotContain(s => s.Id == oldSaleId);
+    }
+
+    [Test]
+    public async Task ShouldFilterByCustomerName()
+    {
+        await RunAsDefaultUserAsync();
+
+        var johnId = await SendAsync(new CreateCustomerCommand { FirstName = "John", LastName = "Smith" });
+        var janeId = await SendAsync(new CreateCustomerCommand { FirstName = "Jane", LastName = "Doe" });
+
+        var johnSale = await SendAsync(new CreateSaleCommand
+        {
+            CustomerId = johnId,
+            Items = [ new SaleItemDto { InventoryProductId = 1, Quantity = 1, UnitPrice = 10 } ]
+        });
+
+        var janeSale = await SendAsync(new CreateSaleCommand
+        {
+            CustomerId = janeId,
+            Items = [ new SaleItemDto { InventoryProductId = 1, Quantity = 1, UnitPrice = 20 } ]
+        });
+
+        var result = await SendAsync(new GetSalesQuery { CustomerName = "Jane" });
+
+        result.Items.Should().ContainSingle(s => s.Id == janeSale);
+        result.Items.Should().NotContain(s => s.Id == johnSale);
+    }
+
+    [Test]
+    public async Task ShouldFilterByCategory()
+    {
+        await RunAsDefaultUserAsync();
+
+        var product2Id = await SendAsync(new CreateInventoryProductCommand
+        {
+            Code = "P2",
+            Name = "Prod2",
+            CategoryId = 2,
+            InventoryId = 1,
+            UnitId = 1,
+            TotalWeight = 0
+        });
+
+        var sale1 = await SendAsync(new CreateSaleCommand
+        {
+            Items = [ new SaleItemDto { InventoryProductId = 1, Quantity = 1, UnitPrice = 10 } ]
+        });
+
+        var sale2 = await SendAsync(new CreateSaleCommand
+        {
+            Items = [ new SaleItemDto { InventoryProductId = product2Id, Quantity = 1, UnitPrice = 20 } ]
+        });
+
+        var result = await SendAsync(new GetSalesQuery { CategoryId = 2 });
+
+        result.Items.Should().ContainSingle(s => s.Id == sale2);
+        result.Items.Should().NotContain(s => s.Id == sale1);
     }
 }


### PR DESCRIPTION
## Summary
- extend sales query with optional filtering parameters
- filter by date, customer, and category in query handler
- expose new filters via API and Angular client
- propagate optional params in sales component
- add functional tests for filtering

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6849e5b604cc832f88dbe8d5b0bcd61f