### PR TITLE
Add specialized stock transaction options

### DIFF
--- a/src/Application/StockTransactions/Commands/CreateStockTransaction/CreateStockTransactionCommandValidator.cs
+++ b/src/Application/StockTransactions/Commands/CreateStockTransaction/CreateStockTransactionCommandValidator.cs
@@ -1,3 +1,6 @@
+using KuyumcuStokTakip.Domain.Enums;
+using KuyumcuStokTakip.Domain.Entities;
+
 namespace KuyumcuStokTakip.Application.StockTransactions.Commands.CreateStockTransaction;
 
 public class CreateStockTransactionCommandValidator : AbstractValidator<CreateStockTransactionCommand>
@@ -13,5 +16,16 @@ public class CreateStockTransactionCommandValidator : AbstractValidator<CreateSt
         RuleFor(v => v.PureUnitPrice).GreaterThanOrEqualTo(0);
         RuleFor(v => v.LaborUnitPrice).GreaterThanOrEqualTo(0);
         RuleFor(v => v.TotalCost).GreaterThanOrEqualTo(0);
+
+        When(v => v.TransactionType == TransactionType.Return, () =>
+        {
+            RuleFor(v => v.CustomerId).NotNull();
+            RuleFor(v => v.Type).Equal(EStockTransactionType.In);
+        });
+
+        When(v => v.TransactionType == TransactionType.Wastage, () =>
+        {
+            RuleFor(v => v.Type).Equal(EStockTransactionType.Out);
+        });
     }
 }

--- a/tests/Application.FunctionalTests/StockBalances/Queries/GetStockBalanceTests.cs
+++ b/tests/Application.FunctionalTests/StockBalances/Queries/GetStockBalanceTests.cs
@@ -1,5 +1,6 @@
 using KuyumcuStokTakip.Application.StockTransactions.Commands.CreateStockTransaction;
 using KuyumcuStokTakip.Application.StockBalances.Queries.GetStockBalance;
+using KuyumcuStokTakip.Domain.Entities;
 using KuyumcuStokTakip.Domain.Enums;
 using System.Linq;
 


### PR DESCRIPTION
## Summary
- add logic to handle Wastage, Return and Exchange when creating stock transactions
- ensure transaction type rules in the validator
- fix functional test namespace imports

## Testing
- `dotnet test --filter "FullyQualifiedName\!~AcceptanceTests"` *(fails: Testcontainers could not start)*

------
https://chatgpt.com/codex/tasks/task_e_6849f063536c832fbb365cf1a0bd6619