### PR TITLE
Add search filtering to stock balance query

### DIFF
--- a/src/Application/StockBalances/Queries/GetStockBalance/GetStockBalanceQuery.cs
+++ b/src/Application/StockBalances/Queries/GetStockBalance/GetStockBalanceQuery.cs
@@ -7,7 +7,7 @@ namespace KuyumcuStokTakip.Application.StockBalances.Queries.GetStockBalance;
 
 public record GetStockBalanceQuery : IRequest<List<StockBalanceDto>>
 {
-    public string? Search { get; init; }
+    public string? SearchTerm { get; init; }
 }
 
 public class GetStockBalanceQueryHandler : IRequestHandler<GetStockBalanceQuery, List<StockBalanceDto>>
@@ -25,9 +25,9 @@ public class GetStockBalanceQueryHandler : IRequestHandler<GetStockBalanceQuery,
             .Include(t => t.InventoryProduct)
             .AsQueryable();
 
-        if (!string.IsNullOrWhiteSpace(request.Search))
+        if (!string.IsNullOrWhiteSpace(request.SearchTerm))
         {
-            query = query.Where(t => t.InventoryProduct.Name.Contains(request.Search!));
+            query = query.Where(t => t.InventoryProduct.Name.Contains(request.SearchTerm!));
         }
 
         return await query

--- a/src/Web/ClientApp/src/app/web-api-client.ts
+++ b/src/Web/ClientApp/src/app/web-api-client.ts
@@ -1718,7 +1718,7 @@ export class SalesClient implements ISalesClient {
 }
 
 export interface IStockBalancesClient {
-    getStockBalances(search: string | null | undefined): Observable<StockBalanceDto[]>;
+    getStockBalances(searchTerm: string | null | undefined): Observable<StockBalanceDto[]>;
 }
 
 @Injectable({
@@ -1734,10 +1734,10 @@ export class StockBalancesClient implements IStockBalancesClient {
         this.baseUrl = baseUrl ?? "";
     }
 
-    getStockBalances(search: string | null | undefined): Observable<StockBalanceDto[]> {
+    getStockBalances(searchTerm: string | null | undefined): Observable<StockBalanceDto[]> {
         let url_ = this.baseUrl + "/api/StockBalances?";
-        if (search !== undefined && search !== null)
-            url_ += "search=" + encodeURIComponent("" + search) + "&";
+        if (searchTerm !== undefined && searchTerm !== null)
+            url_ += "SearchTerm=" + encodeURIComponent("" + searchTerm) + "&";
         url_ = url_.replace(/[?&]$/, "");
 
         let options_ : any = {

--- a/src/Web/wwwroot/api/specification.json
+++ b/src/Web/wwwroot/api/specification.json
@@ -1043,7 +1043,7 @@
         "operationId": "GetStockBalances",
         "parameters": [
           {
-            "name": "search",
+            "name": "SearchTerm",
             "in": "query",
             "schema": {
               "type": "string",

--- a/tests/Application.FunctionalTests/StockBalances/Queries/GetStockBalanceTests.cs
+++ b/tests/Application.FunctionalTests/StockBalances/Queries/GetStockBalanceTests.cs
@@ -1,4 +1,5 @@
 using KuyumcuStokTakip.Application.StockTransactions.Commands.CreateStockTransaction;
+using KuyumcuStokTakip.Application.InventoryProducts.Commands.CreateInventoryProduct;
 using KuyumcuStokTakip.Application.StockBalances.Queries.GetStockBalance;
 using KuyumcuStokTakip.Domain.Entities;
 using KuyumcuStokTakip.Domain.Enums;
@@ -43,6 +44,49 @@ public class GetStockBalanceTests : BaseTestFixture
         balance.TotalIn.Should().Be(5);
         balance.TotalOut.Should().Be(2);
         balance.NetQuantity.Should().Be(3);
+    }
+
+    [Test]
+    public async Task ShouldFilterByProductName()
+    {
+        await RunAsDefaultUserAsync();
+
+        var productId = await SendAsync(new CreateInventoryProductCommand
+        {
+            Code = "P2",
+            Name = "Silver Ring",
+            CategoryId = 1,
+            InventoryId = 1,
+            UnitId = 1,
+            TotalWeight = 1
+        });
+
+        await SendAsync(new CreateStockTransactionCommand
+        {
+            InventoryProductId = productId,
+            ProductId = productId,
+            Quantity = 4,
+            Weight = 4,
+            UnitPriceType = EUnitPriceType.Milyem,
+            Type = EStockTransactionType.In,
+            TransactionType = TransactionType.Purchase
+        });
+
+        await SendAsync(new CreateStockTransactionCommand
+        {
+            InventoryProductId = 1,
+            ProductId = 1,
+            Quantity = 1,
+            Weight = 1,
+            UnitPriceType = EUnitPriceType.Milyem,
+            Type = EStockTransactionType.In,
+            TransactionType = TransactionType.Purchase
+        });
+
+        var result = await SendAsync(new GetStockBalanceQuery { SearchTerm = "Silver" });
+
+        result.Should().ContainSingle();
+        result.First().InventoryProductId.Should().Be(productId);
     }
 }
 


### PR DESCRIPTION
## Summary
- add `SearchTerm` parameter for stock balance query
- filter results by product name when a search term is provided
- expose the query parameter via HTTP endpoint and API client
- update OpenAPI spec
- add functional test for filtering behaviour

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849fe3003c0832fb3b56d39e76a8d4b