### PR TITLE
Remove include from stock balance query

### DIFF
--- a/src/Application/StockBalances/Queries/GetStockBalance/GetStockBalanceQuery.cs
+++ b/src/Application/StockBalances/Queries/GetStockBalance/GetStockBalanceQuery.cs
@@ -22,7 +22,6 @@ public class GetStockBalanceQueryHandler : IRequestHandler<GetStockBalanceQuery,
     public async Task<List<StockBalanceDto>> Handle(GetStockBalanceQuery request, CancellationToken cancellationToken)
     {
         var query = _context.StockTransactions
-            .Include(t => t.InventoryProduct)
             .AsQueryable();
 
         if (!string.IsNullOrWhiteSpace(request.SearchTerm))

--- a/tests/Application.FunctionalTests/StockBalances/Queries/GetStockBalanceTests.cs
+++ b/tests/Application.FunctionalTests/StockBalances/Queries/GetStockBalanceTests.cs
@@ -41,6 +41,7 @@ public class GetStockBalanceTests : BaseTestFixture
         var result = await SendAsync(new GetStockBalanceQuery());
         var balance = result.First(x => x.ProductId == 1);
 
+        balance.ProductName.Should().Be("Altın Bilezik");
         balance.TotalIn.Should().Be(5);
         balance.TotalOut.Should().Be(2);
         balance.Net.Should().Be(3);
@@ -86,7 +87,9 @@ public class GetStockBalanceTests : BaseTestFixture
         var result = await SendAsync(new GetStockBalanceQuery { SearchTerm = "Silver" });
 
         result.Should().ContainSingle();
-        result.First().ProductId.Should().Be(productId);
+        var balance = result.First();
+        balance.ProductId.Should().Be(productId);
+        balance.ProductName.Should().Be("Silver Ring");
     }
 }
 


### PR DESCRIPTION
## Summary
- remove unnecessary `Include` from stock balance query
- verify grouped product names in functional tests

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: A compatible .NET SDK was not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a0216853c832f80fdc056ec94a37c